### PR TITLE
Add server API route to improve  accessing of KV environmentals

### DIFF
--- a/src/app/api/activity/route.ts
+++ b/src/app/api/activity/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from "next/server";
+import getLatestActivity from "@/app/api/getLatestActivity";
+
+export async function GET() {
+  try {
+    const activity = await getLatestActivity();
+    return NextResponse.json(activity);
+  } catch (error) {
+    console.error("API Route Error:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch activity" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/components/Footer.tsx
+++ b/src/app/components/Footer.tsx
@@ -31,20 +31,29 @@ export default function Footer() {
   const year = moment().year();
 
   // Strava Activity Fetching
-  async function fetchActivity() {
+  const fetchActivity = async () => {
     try {
       setLoading(true);
       setError(null);
-      const latestActivity = await getLatestActivity();
+
+      const response = await fetch("/api/activity");
+      if (!response.ok) {
+        throw new Error("Failed to fetch activity");
+      }
+
+      const latestActivity = await response.json();
       setActivity(latestActivity);
-    } catch (err: any) {
-      console.error("Footer: Error fetching activity:", err.message);
+    } catch (err) {
+      console.error(
+        "Footer: Error fetching activity:",
+        err instanceof Error ? err.message : err,
+      );
       setError("Failed to load most-recent activity");
       setActivity(null);
     } finally {
       setLoading(false);
     }
-  }
+  };
 
   // Goodreads Book Fetching
   async function fetchBooks() {


### PR DESCRIPTION
This PR moves the call for getLatestActivity out of the client footer component and into an api route. I think the production website is unable to access the KV environmentals in the Footer as a client component. Will test in production and confirm this resolves current error.