### PR TITLE
Fix/live feed reading listening sections

### DIFF
--- a/goodreads-lambda/handler.ts
+++ b/goodreads-lambda/handler.ts
@@ -21,10 +21,10 @@ function decodeHtmlEntities(text: string): string {
 export const getCurrentlyReading = async (
   event: APIGatewayProxyEvent,
 ): Promise<APIGatewayProxyResult> => {
-  console.log(
-    "getCurrentlyReading Lambda function called",
-    JSON.stringify(event.queryStringParameters),
-  );
+  // console.log(
+  //   "getCurrentlyReading Lambda function called",
+  //   JSON.stringify(event.queryStringParameters),
+  // );
 
   const queryParams = event.queryStringParameters || {};
   const limit = parseInt(queryParams.limit || "5", 10);

--- a/goodreads-lambda/handler.ts
+++ b/goodreads-lambda/handler.ts
@@ -21,6 +21,11 @@ function decodeHtmlEntities(text: string): string {
 export const getCurrentlyReading = async (
   event: APIGatewayProxyEvent,
 ): Promise<APIGatewayProxyResult> => {
+  console.log(
+    "getCurrentlyReading Lambda function called",
+    JSON.stringify(event.queryStringParameters),
+  );
+
   const queryParams = event.queryStringParameters || {};
   const limit = parseInt(queryParams.limit || "5", 10);
   const shelf = "currently-reading"; // Force the shelf to be "currently-reading"
@@ -50,7 +55,7 @@ export const getCurrentlyReading = async (
     const userId = process.env.GOODREADS_USER_ID || "24890536";
 
     // Use the shelf-specific RSS feed URL
-    const feedUrl = `https://www.goodreads.com/review/list_rss/${userId}?shelf=${shelf}`;
+    const feedUrl = `https://www.goodreads.com/review/list_rss/${userId}-zach?shelf=${shelf}`;
 
     const response = await fetch(feedUrl, {
       headers: {
@@ -124,9 +129,24 @@ export const getCurrentlyReading = async (
       };
     });
 
+    // Process the books data
+    const processedBooks = books.map((book: any) => {
+      // Extract book information
+      return {
+        title: book.title,
+        author: book.author,
+        coverImg: book.coverImg || book.image_url,
+        link: book.link || book.url,
+        // Add reading progress information
+        currentPage: 156, // Hardcoded for now, replace with actual data when available
+        totalPages: 464, // Hardcoded for now, replace with actual data when available
+        lastUpdated: new Date().toISOString(), // Current timestamp
+      };
+    });
+
     // Cache and return response
     cachedData[cacheKey] = {
-      books,
+      books: processedBooks,
       timestamp: new Date().toISOString(),
       status: "success",
     };

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "eslint": "8.39.0",
         "eslint-config-next": "13.3.1",
         "eslint-plugin-prettier": "^5.2.3",
-        "fast-xml-parser": "^4.5.1",
+        "fast-xml-parser": "^4.5.3",
         "moment": "^2.30.1",
         "next": "^13.5.4",
         "node-fetch": "^3.3.2",
@@ -2076,22 +2076,18 @@
       "license": "MIT"
     },
     "node_modules/fast-xml-parser": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.1.tgz",
-      "integrity": "sha512-y655CeyUQ+jj7KBbYMc4FG01V8ZQqjN+gDYGJ50RtfsUB8iG9AmwmwoAgeKLJdmueKKMrH1RJ7yXHTSoczdv5w==",
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.3.tgz",
+      "integrity": "sha512-RKihhV+SHsIUGXObeVy9AXiBbFwkVk7Syp8XgwN5U3JV416+Gwp/GO9i0JYKmikykgz/UHRrrV4ROuZEo/T0ig==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/NaturalIntelligence"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/naturalintelligence"
         }
       ],
       "license": "MIT",
       "dependencies": {
-        "strnum": "^1.0.5"
+        "strnum": "^1.1.1"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -4762,9 +4758,15 @@
       }
     },
     "node_modules/strnum": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
-      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.1.2.tgz",
+      "integrity": "sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
       "license": "MIT"
     },
     "node_modules/styled-jsx": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "eslint": "8.39.0",
     "eslint-config-next": "13.3.1",
     "eslint-plugin-prettier": "^5.2.3",
-    "fast-xml-parser": "^4.5.1",
+    "fast-xml-parser": "^4.5.3",
     "moment": "^2.30.1",
     "next": "^13.5.4",
     "node-fetch": "^3.3.2",

--- a/scripts/verify-env.ts
+++ b/scripts/verify-env.ts
@@ -18,5 +18,5 @@ if (missingVars.length > 0) {
   console.error("Missing required environment variables:", missingVars);
   process.exit(1);
 } else {
-  console.log("All required environment variables are set");
+  // console.log("All required environment variables are set");
 }

--- a/src/app/api/goodreads/audiobooks/route.ts
+++ b/src/app/api/goodreads/audiobooks/route.ts
@@ -39,7 +39,7 @@ export async function GET(request: Request) {
         console.warn("KV cache error:", kvError);
       }
     } else {
-      console.log("Force refresh requested, skipping cache");
+      // console.log("Force refresh requested, skipping cache");
     }
 
     // Use production Lambda URL from environment variables
@@ -99,7 +99,7 @@ export async function GET(request: Request) {
       // Cache the processed audiobooks
       try {
         await kv.set(CACHE_KEY, normalizedAudiobooks, { ex: CACHE_DURATION });
-        console.log("Data cached successfully for 5 minutes");
+        // console.log("Data cached successfully for 5 minutes");
       } catch (cacheError) {
         console.warn("Failed to cache data:", cacheError);
       }

--- a/src/app/api/goodreads/audiobooks/route.ts
+++ b/src/app/api/goodreads/audiobooks/route.ts
@@ -12,7 +12,8 @@ interface Audiobook {
   dateRead: string;
   _error?: string;
 }
-// Create KV client with the new environment variables
+
+// Create KV client with the environment variables
 const kv = createClient({
   url: process.env.KV_KV_REST_API_URL || "",
   token: process.env.KV_KV_REST_API_TOKEN || "",
@@ -20,11 +21,12 @@ const kv = createClient({
 
 export const dynamic = "force-dynamic";
 const CACHE_KEY = "goodreads_audiobooks";
-const CACHE_DURATION = 3600; // 1 hour
+const CACHE_DURATION = 300; // 5 minutes
 
 export async function GET(request: Request) {
   const url = new URL(request.url);
   const forceRefresh = url.searchParams.get("refresh") === "true";
+
   try {
     // Try to get cached data first (unless force refresh)
     if (!forceRefresh) {
@@ -36,45 +38,77 @@ export async function GET(request: Request) {
       } catch (kvError) {
         console.warn("KV cache error:", kvError);
       }
+    } else {
+      console.log("Force refresh requested, skipping cache");
     }
 
-    // Determine which URL to use based on environment
+    // Use production Lambda URL from environment variables
     const lambdaUrl = process.env.GOODREADS_GETAUDIOBOOKS_URL_PROD;
 
     if (!lambdaUrl) {
-      throw new Error("Lambda URL is not defined");
+      console.error("Lambda URL is not defined");
+      throw new Error("Lambda URL is not defined in environment variables");
     }
 
     // Fetch data from Lambda function with timeout
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), 8000); // 8 second timeout
 
-    const response = await fetch(lambdaUrl, {
-      method: "GET",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      signal: controller.signal,
-    });
-
-    clearTimeout(timeoutId);
-
-    if (!response.ok) {
-      const errorText = await response.text();
-      console.error(`Lambda error: ${response.status}`, errorText);
-      throw new Error(`Lambda returned ${response.status}: ${errorText}`);
-    }
-
-    const data = await response.json();
-
-    // Cache the data
     try {
-      await kv.set(CACHE_KEY, data, { ex: CACHE_DURATION });
-    } catch (cacheError) {
-      console.warn("Failed to cache data:", cacheError);
-    }
+      const response = await fetch(lambdaUrl, {
+        method: "GET",
+        headers: {
+          "Content-Type": "application/json",
+          "Cache-Control": "no-cache",
+        },
+        signal: controller.signal,
+      });
 
-    return NextResponse.json(data);
+      clearTimeout(timeoutId);
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        console.error(`Lambda error: ${response.status}`, errorText);
+        throw new Error(`Lambda returned ${response.status}: ${errorText}`);
+      }
+
+      const data = await response.json();
+
+      // Extract and normalize audiobooks from the response
+      let audiobooks: Audiobook[] = [];
+
+      if (Array.isArray(data)) {
+        audiobooks = data;
+      } else if (data && data.books && Array.isArray(data.books)) {
+        audiobooks = data.books;
+      } else {
+        console.error("Unexpected data format from Lambda:", data);
+        throw new Error("Invalid data format from Lambda");
+      }
+
+      // Normalize the audiobooks data
+      const normalizedAudiobooks = audiobooks.map((book) => ({
+        title: book.title,
+        author: book.author,
+        coverImg: book.coverImg || book.coverUrl || null,
+        link: book.link || book.bookLink || null,
+        dateRead: book.dateRead,
+        rating: book.rating,
+      }));
+
+      // Cache the processed audiobooks
+      try {
+        await kv.set(CACHE_KEY, normalizedAudiobooks, { ex: CACHE_DURATION });
+        console.log("Data cached successfully for 5 minutes");
+      } catch (cacheError) {
+        console.warn("Failed to cache data:", cacheError);
+      }
+
+      return NextResponse.json(normalizedAudiobooks);
+    } catch (fetchError) {
+      console.error("Error fetching from Lambda:", fetchError);
+      throw fetchError;
+    }
   } catch (error) {
     console.error("Error fetching audiobooks:", error);
 
@@ -82,14 +116,13 @@ export async function GET(request: Request) {
     try {
       const staleData = await kv.get(CACHE_KEY);
       if (staleData) {
-        console.log("Using stale data from cache as fallback");
         return NextResponse.json(staleData);
       }
     } catch (fallbackError) {
       console.error("Failed to get stale data:", fallbackError);
     }
 
-    //Fallback data in case the API fails
+    // Return hardcoded fallback data in case the API fails
     const fallbackAudiobooks: Audiobook[] = [
       {
         title: "Good Inside",
@@ -120,7 +153,6 @@ export async function GET(request: Request) {
       },
     ];
 
-    console.log("Using hardcoded fallback audiobooks data");
     return NextResponse.json(fallbackAudiobooks);
   }
 }

--- a/src/app/api/goodreads/clear-cache/route.ts
+++ b/src/app/api/goodreads/clear-cache/route.ts
@@ -11,7 +11,7 @@ export async function GET() {
   try {
     // List all keys for debugging
     const keys = await kv.keys("*");
-    console.log("All keys before deletion:", keys);
+    // console.log("All keys before deletion:", keys);
 
     // Delete the cached data
     let deletedKeys = [];

--- a/src/app/api/goodreads/currently-reading/route.ts
+++ b/src/app/api/goodreads/currently-reading/route.ts
@@ -1,101 +1,266 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextResponse } from "next/server";
+import { createClient } from "@vercel/kv";
 import { XMLParser } from "fast-xml-parser";
-import { kv } from "@vercel/kv";
 
 export const dynamic = "force-dynamic";
 const CACHE_KEY = "goodreads_currently_reading";
-const CACHE_DURATION = 3600; // 1 hour
+const CACHE_DURATION = 300; // 5 minutes
 
-interface UserStatus {
+interface Book {
   title: string;
   author: string;
-  currentPage: number;
-  totalPages: number;
-  link: string;
-  coverImg: string | null;
-  lastUpdated: string;
+  coverImg?: string | null;
+  link?: string | null;
+  currentPage?: number | null;
+  totalPages?: number | null;
+  lastUpdated?: string | null;
 }
 
-// Helper function to strip HTML tags
-function stripHtml(html: string): string {
-  return html.replace(/<[^>]*>/g, "");
+interface RssItem {
+  title: string;
+  author_name?: string;
+  link?: string;
+  book_large_image_url?: string;
+  book_medium_image_url?: string;
+  book_small_image_url?: string;
+  num_pages?: string;
+  user_date_added?: string;
+  pubDate?: string;
 }
 
-export async function GET() {
+// Create KV client
+const kv = createClient({
+  url: process.env.KV_KV_REST_API_URL || "",
+  token: process.env.KV_KV_REST_API_TOKEN || "",
+});
+
+export async function GET(request: Request) {
+  // Check for force refresh parameter
+  const url = new URL(request.url);
+  const forceRefresh = url.searchParams.get("refresh") === "true";
+
   try {
-    // Try to get cached data first
-    let cachedData = null;
-    try {
-      cachedData = await kv.get(CACHE_KEY);
-      if (cachedData) {
-        return NextResponse.json(cachedData);
+    // Try to get cached data first (unless force refresh)
+    if (!forceRefresh) {
+      try {
+        const cachedData = await kv.get(CACHE_KEY);
+        if (cachedData) {
+          return NextResponse.json(cachedData);
+        }
+      } catch (kvError) {
+        console.warn("KV cache error:", kvError);
       }
-    } catch (kvError) {
-      console.warn("KV cache error:", kvError);
+    } else {
+      console.log("Force refresh requested, skipping cache");
     }
 
-    // Determine which URL to use based on environment
-    const lambdaUrl = process.env.GOODREADS_GETCURRENTLYREADING_URL_PROD;
-
-    if (!lambdaUrl) {
-      throw new Error("Lambda URL is not defined");
-    }
-
-    // Fetch data from Lambda function with timeout
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), 8000); // 8 second timeout
-
+    // Fetch data from both RSS feeds
     try {
-      const response = await fetch(lambdaUrl, {
-        method: "GET",
+      // 1. First get the updates feed to find reading progress
+      const userId = process.env.GOODREADS_USER_ID || "24890536";
+      const updatesUrl = `https://www.goodreads.com/user/updates_rss/${userId}`;
+
+      const updatesResponse = await fetch(updatesUrl, {
         headers: {
-          "Content-Type": "application/json",
+          "User-Agent": "Mozilla/5.0 (compatible; GoodreadsApp/1.0)",
+          "Cache-Control": "no-cache",
         },
-        signal: controller.signal,
+        next: { revalidate: 3600 }, // Cache for 1 hour
       });
 
-      clearTimeout(timeoutId);
-
-      if (!response.ok) {
-        const errorText = await response.text();
-        console.error(`Lambda error: ${response.status}`, errorText);
-        throw new Error(`Lambda returned ${response.status}: ${errorText}`);
+      if (!updatesResponse.ok) {
+        throw new Error(`Updates feed HTTP error: ${updatesResponse.status}`);
       }
 
-      const rawData = await response.text();
+      const updatesXml = await updatesResponse.text();
+      const xmlParser = new XMLParser({
+        ignoreAttributes: false,
+        parseAttributeValue: true,
+      });
 
-      // Parse the JSON data
-      const data = JSON.parse(rawData);
+      const updatesResult = xmlParser.parse(updatesXml);
 
-      // Extract the books array
-      const books = data.books || [];
+      // 2. Then get the currently-reading shelf
+      const shelfUrl = `https://www.goodreads.com/review/list_rss/${userId}?shelf=currently-reading&sort=date_updated&order=d`;
 
-      // Cache the books array
+      const shelfResponse = await fetch(shelfUrl, {
+        headers: {
+          "User-Agent": "Mozilla/5.0 (compatible; GoodreadsApp/1.0)",
+          "Cache-Control": "no-cache",
+        },
+        next: { revalidate: 3600 }, // Cache for 1 hour
+      });
+
+      if (!shelfResponse.ok) {
+        throw new Error(`Shelf feed HTTP error: ${shelfResponse.status}`);
+      }
+
+      const shelfXml = await shelfResponse.text();
+      const shelfResult = xmlParser.parse(shelfXml);
+
+      // 3. Process the updates feed to find reading progress
+      const progressUpdates: Record<
+        string,
+        { currentPage: number; totalPages: number; lastUpdated: string }
+      > = {};
+
+      if (updatesResult.rss?.channel?.item) {
+        const items = Array.isArray(updatesResult.rss.channel.item)
+          ? updatesResult.rss.channel.item
+          : [updatesResult.rss.channel.item];
+
+        for (const item of items) {
+          // Look for status updates with reading progress
+          if (item.title && typeof item.title === "string") {
+            const progressRegex = /is on page (\d+) of (\d+) of (.+)$/i;
+            const match = item.title.match(progressRegex);
+
+            if (match) {
+              const currentPage = parseInt(match[1], 10);
+              const totalPages = parseInt(match[2], 10);
+              const bookTitle = match[3].trim();
+              const lastUpdated = item.pubDate || new Date().toISOString();
+
+              progressUpdates[bookTitle] = {
+                currentPage,
+                totalPages,
+                lastUpdated,
+              };
+            }
+
+            // Also look for "is X% done with" updates
+            const percentRegex = /is (\d+)% done with (.+)$/i;
+            const percentMatch = item.title.match(percentRegex);
+
+            if (percentMatch && !progressUpdates[percentMatch[2].trim()]) {
+              const percent = parseInt(percentMatch[1], 10);
+              const bookTitle = percentMatch[2].trim();
+              const lastUpdated = item.pubDate || new Date().toISOString();
+
+              // We don't know total pages from this update, but we'll set it later
+              progressUpdates[bookTitle] = {
+                currentPage: -1, // Placeholder, will calculate after getting total pages
+                totalPages: -1, // Placeholder
+                lastUpdated,
+              };
+            }
+          }
+        }
+      }
+
+      // 4. Process the shelf feed to get book details
+      let books: Book[] = [];
+
+      if (shelfResult.rss?.channel?.item) {
+        const items = Array.isArray(shelfResult.rss.channel.item)
+          ? shelfResult.rss.channel.item
+          : [shelfResult.rss.channel.item];
+
+        books = items.map((item: RssItem) => {
+          const title = item.title || "Unknown Title";
+          const author = item.author_name || "Unknown Author";
+          const link = item.link || null;
+
+          // Get cover image
+          let coverImg = null;
+          if (item.book_large_image_url) {
+            coverImg = item.book_large_image_url;
+          } else if (item.book_medium_image_url) {
+            coverImg = item.book_medium_image_url;
+          } else if (item.book_small_image_url) {
+            coverImg = item.book_small_image_url;
+          }
+
+          // Get total pages
+          let totalPages = null;
+          if (item.num_pages) {
+            totalPages = parseInt(item.num_pages, 10);
+          }
+
+          // Check if we have progress data for this book
+          let currentPage = null;
+          let lastUpdated = item.user_date_added || null;
+
+          if (progressUpdates[title]) {
+            currentPage = progressUpdates[title].currentPage;
+
+            // If we only had percent data, calculate pages
+            if (currentPage === -1 && totalPages) {
+              // Extract percent from the title
+              const percentRegex = /is (\d+)% done with/i;
+              const percentMatch = Object.keys(progressUpdates).find(
+                (key) => key.includes(title) && percentRegex.test(key),
+              );
+
+              if (percentMatch) {
+                const percent = parseInt(
+                  percentMatch.match(percentRegex)![1],
+                  10,
+                );
+                currentPage = Math.floor(totalPages * (percent / 100));
+              }
+            }
+
+            // Use total pages from progress update if available
+            if (progressUpdates[title].totalPages > 0) {
+              totalPages = progressUpdates[title].totalPages;
+            }
+
+            lastUpdated = progressUpdates[title].lastUpdated;
+          }
+
+          // If we still don't have current page but have total pages, estimate
+          if (!currentPage && totalPages) {
+            currentPage = Math.floor(totalPages * 0.3); // Assume 30% through
+          }
+
+          return {
+            title,
+            author,
+            coverImg,
+            link,
+            currentPage,
+            totalPages,
+            lastUpdated,
+          };
+        });
+      }
+
+      // 5. Sort books by lastUpdated (most recent first)
+      if (books.length > 0) {
+        books.sort((a, b) => {
+          const dateA = a.lastUpdated ? new Date(a.lastUpdated).getTime() : 0;
+          const dateB = b.lastUpdated ? new Date(b.lastUpdated).getTime() : 0;
+          return dateB - dateA; // Most recent first
+        });
+      }
+
+      // Cache the processed books
       try {
         await kv.set(CACHE_KEY, books, { ex: CACHE_DURATION });
-      } catch (kvSetError) {
-        console.warn("KV set error:", kvSetError);
+      } catch (cacheError) {
+        console.warn("Failed to cache data:", cacheError);
       }
 
       return NextResponse.json(books);
     } catch (fetchError) {
-      clearTimeout(timeoutId);
+      console.error("Error fetching from RSS feeds:", fetchError);
       throw fetchError;
     }
   } catch (error) {
     console.error("Error fetching currently reading books:", error);
 
-    // Try to get stale data as fallback
+    // Try to get stale data from cache as fallback
     try {
-      const staleData = await kv.get("goodreads_currently_reading_stale");
+      const staleData = await kv.get(CACHE_KEY);
       if (staleData) {
         return NextResponse.json(staleData);
       }
-    } catch (staleError) {
-      console.warn("Stale cache error:", staleError);
+    } catch (fallbackError) {
+      console.error("Failed to get stale data:", fallbackError);
     }
 
-    // Return a fallback empty array with a 500 status
+    // Return a fallback empty array
     return NextResponse.json(
       {
         error: "Failed to fetch currently reading books",

--- a/src/app/api/goodreads/read-books/route.ts
+++ b/src/app/api/goodreads/read-books/route.ts
@@ -1,18 +1,19 @@
 import { NextResponse } from "next/server";
 import { createClient } from "@vercel/kv";
+
 interface Book {
   title: string;
   author: string;
   coverImg?: string | null;
   coverUrl?: string;
-  link: string;
+  link?: string;
   bookLink?: string;
   dateRead: string;
   rating: number;
   _error?: string;
 }
 
-// Create KV client with the new environment variables
+// Create KV client with the environment variables
 const kv = createClient({
   url: process.env.KV_KV_REST_API_URL || "",
   token: process.env.KV_KV_REST_API_TOKEN || "",
@@ -20,7 +21,7 @@ const kv = createClient({
 
 export const dynamic = "force-dynamic";
 const CACHE_KEY = "goodreads_read_books";
-const CACHE_DURATION = 3600; // 1 hour
+const CACHE_DURATION = 300; // 5 minutes (reduced from 1 hour)
 
 export async function GET(request: Request) {
   // Check for force refresh parameter
@@ -38,45 +39,76 @@ export async function GET(request: Request) {
       } catch (kvError) {
         console.warn("KV cache error:", kvError);
       }
+    } else {
+      console.log("Force refresh requested, skipping cache");
     }
 
-    // Determine which URL to use based on environment
+    // Use the production Lambda URL from environment variables
     const lambdaUrl = process.env.GOODREADS_GETREADBOOKS_URL_PROD;
 
     if (!lambdaUrl) {
-      throw new Error("Lambda URL is not defined");
+      console.error("Lambda URL is not defined");
+      throw new Error("Lambda URL is not defined in environment variables");
     }
 
     // Fetch data from Lambda function with timeout
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), 8000); // 8 second timeout
 
-    const response = await fetch(lambdaUrl, {
-      method: "GET",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      signal: controller.signal,
-    });
-
-    clearTimeout(timeoutId);
-
-    if (!response.ok) {
-      const errorText = await response.text();
-      console.error(`Lambda error: ${response.status}`, errorText);
-      throw new Error(`Lambda returned ${response.status}: ${errorText}`);
-    }
-
-    const data = await response.json();
-
-    // Cache the data
     try {
-      await kv.set(CACHE_KEY, data, { ex: CACHE_DURATION });
-    } catch (cacheError) {
-      console.warn("Failed to cache data:", cacheError);
-    }
+      const response = await fetch(lambdaUrl, {
+        method: "GET",
+        headers: {
+          "Content-Type": "application/json",
+          "Cache-Control": "no-cache",
+        },
+        signal: controller.signal,
+      });
 
-    return NextResponse.json(data);
+      clearTimeout(timeoutId);
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        console.error(`Lambda error: ${response.status}`, errorText);
+        throw new Error(`Lambda returned ${response.status}: ${errorText}`);
+      }
+
+      const data = await response.json();
+
+      // Extract and normalize books from the response
+      let books: Book[] = [];
+
+      if (Array.isArray(data)) {
+        books = data;
+      } else if (data && data.books && Array.isArray(data.books)) {
+        books = data.books;
+      } else {
+        console.error("Unexpected data format from Lambda:", data);
+        throw new Error("Invalid data format from Lambda");
+      }
+
+      // Normalize the books data
+      const normalizedBooks = books.map((book) => ({
+        title: book.title,
+        author: book.author,
+        coverImg: book.coverImg || book.coverUrl || null,
+        link: book.link || book.bookLink || null,
+        dateRead: book.dateRead,
+        rating: book.rating,
+      }));
+
+      // Cache the processed books
+      try {
+        await kv.set(CACHE_KEY, normalizedBooks, { ex: CACHE_DURATION });
+      } catch (cacheError) {
+        console.warn("Failed to cache data:", cacheError);
+      }
+
+      return NextResponse.json(normalizedBooks);
+    } catch (fetchError) {
+      console.error("Error fetching from Lambda:", fetchError);
+      throw fetchError;
+    }
   } catch (error) {
     console.error("Error fetching read books:", error);
 
@@ -84,7 +116,6 @@ export async function GET(request: Request) {
     try {
       const staleData = await kv.get(CACHE_KEY);
       if (staleData) {
-        console.log("Using stale data from cache as fallback");
         return NextResponse.json(staleData);
       }
     } catch (fallbackError) {
@@ -119,7 +150,6 @@ export async function GET(request: Request) {
       },
     ];
 
-    console.log("Using hardcoded fallback books data");
     return NextResponse.json(fallbackBooks);
   }
 }

--- a/src/app/api/goodreads/read-books/route.ts
+++ b/src/app/api/goodreads/read-books/route.ts
@@ -40,7 +40,7 @@ export async function GET(request: Request) {
         console.warn("KV cache error:", kvError);
       }
     } else {
-      console.log("Force refresh requested, skipping cache");
+      // console.log("Force refresh requested, skipping cache");
     }
 
     // Use the production Lambda URL from environment variables

--- a/src/app/api/goodreads/route.ts
+++ b/src/app/api/goodreads/route.ts
@@ -37,3 +37,4 @@ export async function GET(request: NextRequest) {
     );
   }
 }
+// INCORRECT LAMBDA URL. IS THIS STILL USED? DELETE?

--- a/src/app/components/CurrentlyReading.tsx
+++ b/src/app/components/CurrentlyReading.tsx
@@ -3,7 +3,7 @@
 import React, { useEffect, useState } from "react";
 import styles from "./CurrentlyReading.module.css";
 import footerStyles from "./Footer.module.css";
-import moment from "moment";
+import { getTimeAgo } from "@/app/utils/index";
 
 type Book = {
   title: string;
@@ -27,7 +27,9 @@ export default function CurrentlyReading() {
         setLoading(true);
         setError(null);
 
-        const response = await fetch("/api/goodreads/currently-reading");
+        const response = await fetch(
+          "/api/goodreads/currently-reading?refresh=true",
+        );
         const responseText = await response.text();
 
         // Store raw response for debugging
@@ -57,21 +59,57 @@ export default function CurrentlyReading() {
         }
 
         // Check if data is an array or has a books property
+        let booksArray = [];
         if (Array.isArray(data)) {
-          setBooks(data);
+          booksArray = data;
         } else if (data && data.books && Array.isArray(data.books)) {
-          setBooks(data.books);
+          booksArray = data.books;
         } else {
           console.error("Unexpected data format:", data);
           throw new Error("No books data received");
         }
+
+        // Normalize the data to ensure consistent property names
+        const normalizedBooks = booksArray.map((book: any) => ({
+          title: book.title,
+          author: book.author,
+          coverImg: book.coverImg || book.cover_url || null,
+          link: book.link || book.url || null,
+          currentPage: book.currentPage || book.current_page || null,
+          totalPages: book.totalPages || book.total_pages || null,
+          lastUpdated: book.lastUpdated || book.last_updated || null,
+        }));
+
+        console.log("normalizedBooks:", normalizedBooks);
+
+        // Sort books by lastUpdated (most recent first)
+        if (normalizedBooks.length > 0) {
+          normalizedBooks.sort((a: Book, b: Book) => {
+            const dateA = a.lastUpdated ? new Date(a.lastUpdated).getTime() : 0;
+            const dateB = b.lastUpdated ? new Date(b.lastUpdated).getTime() : 0;
+            return dateB - dateA; // Most recent first
+          });
+        }
+
+        setBooks(normalizedBooks);
       } catch (err) {
         console.error("Error fetching currently reading books:", err);
         setError(
           err instanceof Error ? err.message : "An unknown error occurred",
         );
-        // Set a fallback empty array so the UI doesn't break
-        setBooks([]);
+
+        // Set fallback data for testing
+        const fallbackBook: Book = {
+          title: "The Four Winds",
+          author: "Kristin Hannah",
+          currentPage: 156,
+          totalPages: 464,
+          lastUpdated: new Date().toISOString(),
+        };
+
+        setBooks([fallbackBook]);
+        // Comment out the line below to use fallback data instead of showing error
+        // setBooks([]);
       } finally {
         setLoading(false);
       }
@@ -106,8 +144,7 @@ export default function CurrentlyReading() {
       {currentBook.currentPage && currentBook.totalPages && (
         <span className={styles.readingProgress}>
           {` (on page ${currentBook.currentPage}/${currentBook.totalPages}`}
-          {currentBook.lastUpdated &&
-            ` ${moment(currentBook.lastUpdated).fromNow()}`}
+          {currentBook.lastUpdated && ` ${getTimeAgo(currentBook.lastUpdated)}`}
           {")"}
         </span>
       )}

--- a/src/app/components/CurrentlyReading.tsx
+++ b/src/app/components/CurrentlyReading.tsx
@@ -80,7 +80,7 @@ export default function CurrentlyReading() {
           lastUpdated: book.lastUpdated || book.last_updated || null,
         }));
 
-        console.log("normalizedBooks:", normalizedBooks);
+        // console.log("normalizedBooks:", normalizedBooks);
 
         // Sort books by lastUpdated (most recent first)
         if (normalizedBooks.length > 0) {
@@ -125,7 +125,7 @@ export default function CurrentlyReading() {
   if (error) {
     // In development, show debug info
     if (process.env.NODE_ENV === "development" || debugInfo) {
-      console.log("Debug info:", debugInfo);
+      // console.log("Debug info:", debugInfo);
     }
     return <span>Error loading reading progress: {error}</span>;
   }

--- a/src/app/components/Footer.tsx
+++ b/src/app/components/Footer.tsx
@@ -83,11 +83,17 @@ export default function Footer() {
       }
 
       const data = await response.json();
-      if (!data.books) {
+      // Check if data is an array or has a books property
+      let booksArray = [];
+      if (Array.isArray(data)) {
+        booksArray = data;
+      } else if (data && data.books && Array.isArray(data.books)) {
+        booksArray = data.books;
+      } else {
         throw new Error("No books data received");
       }
 
-      setCurrentlyReading(data.books);
+      setCurrentlyReading(booksArray);
     } catch (err) {
       console.error("Error fetching books:", err);
       setBookError(

--- a/src/app/components/Header.module.css
+++ b/src/app/components/Header.module.css
@@ -110,13 +110,19 @@
 }
 
 .gearIcon {
+  position: relative;
+  width: 2.5rem;
+  height: 2.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   background: none;
-  border: none;
   padding: 0;
+  border: none;
   cursor: pointer;
-  height: 2rem;
-  width: 2rem;
   fill: hsl(0, 0%, 100%);
+  padding: 0;
+  opacity: 1;
 }
 
 .gearIcon:hover,

--- a/src/app/components/Preferences/Preferences.module.css
+++ b/src/app/components/Preferences/Preferences.module.css
@@ -272,6 +272,35 @@
   text-align: right;
 }
 
+.gearIconWrapper {
+  position: relative;
+  width: 2.5rem;
+  height: 2.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  border-radius: var(--border-radius);
+  transition: background-color 0.2s ease;
+  -webkit-tap-highlight-color: transparent;
+  transform: translateZ(0);
+  backface-visibility: hidden;
+}
+
+.gearIconWrapper:hover {
+  background-color: var(--clr-neutral-200);
+}
+
+.gearIcon {
+  width: 2.5rem;
+  height: 2.5rem;
+  fill: hsl(0, 0%, 100%);
+  visibility: visible;
+  /* padding: 0.5rem; */
+}
+
 [data-theme="dark"] .toggleLabel {
   color: var(--white);
 }

--- a/src/lib/kv.ts
+++ b/src/lib/kv.ts
@@ -7,7 +7,7 @@ export { kv };
 export async function verifyKVConnection() {
   try {
     await kv.ping();
-    console.log("Successfully connected to KV store");
+    // console.log("Successfully connected to KV store");
     return true;
   } catch (error) {
     console.error("Failed to connect to KV store:", error);

--- a/src/lib/strava/auth.ts
+++ b/src/lib/strava/auth.ts
@@ -18,7 +18,7 @@ export async function getStravaToken(): Promise<TokenData | null> {
 }
 
 export async function refreshStravaToken(): Promise<string> {
-  console.log("Refreshing Strava token...");
+  // console.log("Refreshing Strava token...");
 
   const clientId = process.env.STRAVA_CLIENT_ID;
   const clientSecret = process.env.STRAVA_CLIENT_SECRET;


### PR DESCRIPTION
This PR fixes api routes to return books to to the live-feed page rather than the errors I was currently getting.

I was doing more work to fix routes, but want this to be in production, since I only work on this inbetween all the other life things. So I commented out the console.logs for the process that I was currently debugging, but left them in the code ¯\_(ツ)_/¯. I plan to restore the page detail and time updated back to the footer soon.
