### PR TITLE
Remove initialize function

### DIFF
--- a/src/app/components/Analytics.tsx
+++ b/src/app/components/Analytics.tsx
@@ -34,11 +34,6 @@ function AnalyticsTracker() {
  * Follows the "Keep logic out of views" commandment by delegating to analytics service
  */
 export default function Analytics() {
-  // Initialize analytics on component mount
-  useEffect(() => {
-    analytics.initialize();
-  }, []);
-
   return (
     <Suspense fallback={null}>
       <AnalyticsTracker />

--- a/src/app/utils/analytics.ts
+++ b/src/app/utils/analytics.ts
@@ -22,27 +22,6 @@ const getGtag = () => {
 };
 
 /**
- * Initialize Google Analytics
- */
-const initialize = (): void => {
-  if (!isEnabled()) return;
-
-  // Initialize dataLayer
-  window.dataLayer = window.dataLayer || [];
-  window.gtag = function () {
-    window.dataLayer.push(arguments);
-  };
-
-  // Configure GA
-  const config = getConfig();
-  window.gtag("js", new Date());
-  window.gtag("config", config.measurementId, {
-    page_title: document.title,
-    page_location: window.location.href,
-  });
-};
-
-/**
  * Track page views
  */
 const trackPageView = (pageView: GAPageView): void => {
@@ -101,7 +80,6 @@ const trackExternalLink = (url: string, linkText: string): void => {
 
 // Export clean functional API
 export const analytics = {
-  initialize,
   trackPageView,
   trackEvent,
   trackContactSubmission,


### PR DESCRIPTION
This PR includes the fix of removing the duplicate Google Analytics initialization that was causing conflicts. Once this is merged to main, I'll allow 48 hours to verify whether or not this tag is working correctly. 