### PR TITLE
3🐛 fix(blog): correct timezone handling in datetime picker

### DIFF
--- a/src/app/admin/blog/components/MarkdownEditor.tsx
+++ b/src/app/admin/blog/components/MarkdownEditor.tsx
@@ -417,17 +417,32 @@ export default function MarkdownEditor({
                 type="datetime-local"
                 value={
                   post.scheduledFor
-                    ? new Date(post.scheduledFor).toISOString().slice(0, 16)
+                    ? (() => {
+                        const date = new Date(post.scheduledFor);
+                        const offset = date.getTimezoneOffset() * 60000;
+                        const localDate = new Date(date.getTime() - offset);
+                        return localDate.toISOString().slice(0, 16);
+                      })()
                     : ''
                 }
-                onChange={e =>
-                  handleMetadataChange(
-                    'scheduledFor',
-                    e.target.value ? new Date(e.target.value).toISOString() : ''
-                  )
-                }
+                onChange={e => {
+                  if (e.target.value) {
+                    // Parse the datetime-local value as local time, then convert to UTC
+                    const localDate = new Date(e.target.value);
+                    const offset = localDate.getTimezoneOffset() * 60000;
+                    const utcDate = new Date(localDate.getTime() + offset);
+                    handleMetadataChange('scheduledFor', utcDate.toISOString());
+                  } else {
+                    handleMetadataChange('scheduledFor', '');
+                  }
+                }}
                 className={styles.input}
-                min={new Date().toISOString().slice(0, 16)}
+                min={(() => {
+                  const now = new Date();
+                  const offset = now.getTimezoneOffset() * 60000;
+                  const localNow = new Date(now.getTime() - offset);
+                  return localNow.toISOString().slice(0, 16);
+                })()}
                 required
               />
               <p className={styles.helpText}>


### PR DESCRIPTION
Fixes issue where 1:00 PM input would incorrectly display as 7:00 PM due to improper timezone conversion in the scheduling interface.

- Add proper timezone offset handling for datetime-local input display
- Fix UTC conversion when saving user's local time input
- Update min attribute to respect local timezone constraints
- Ensure consistent timezone behavior across different browsers

Resolves scheduling time picker displaying incorrect times in MST.