### PR TITLE
Enhance/mobile chat UI

### DIFF
--- a/src/components/chat/FloatingChatWidget.module.css
+++ b/src/components/chat/FloatingChatWidget.module.css
@@ -301,22 +301,10 @@
   transform: scale(0.95);
 }
 
-.chatToggleOpen {
-  background: var(--color-text-secondary);
-}
-
-.toggleIcon {
-  color: var(--text-primary);
-  width: 24px;
-  height: 24px;
-  transition: transform 0.2s ease;
-}
-
 .chatBubble {
   transition: transform 0.2s ease;
 }
 
-.chatToggle:hover .toggleIcon,
 .chatToggle:hover .chatIcon {
   transform: scale(1.3);
 }

--- a/src/components/chat/FloatingChatWidget.module.css
+++ b/src/components/chat/FloatingChatWidget.module.css
@@ -330,8 +330,12 @@
 
   .chatContainer {
     width: calc(100vw - 32px);
-    height: 80vh;
-    max-height: 500px;
+    /* Use dvh for dynamic viewport height that accounts for mobile keyboard */
+    height: min(60dvh, 450px);
+    /* Ensure minimum usable height even when keyboard is active */
+    min-height: 300px;
+    /* Use max for better constraint */
+    max-height: min(60dvh, 450px);
     bottom: 70px;
     right: 0;
   }
@@ -346,6 +350,49 @@
   .chatIcon {
     width: 3rem;
     height: 3rem;
+  }
+
+  /* Adjust messages container for better mobile experience */
+  .messagesContainer {
+    /* Give more room to messages, less padding on mobile */
+    padding: 12px;
+    gap: 8px;
+  }
+
+  /* Optimize input area for mobile keyboards */
+  .inputForm {
+    padding: 12px;
+    /* Ensure input area doesn't get too compressed */
+    flex-shrink: 0;
+  }
+
+  /* Make text slightly larger on mobile for better readability */
+  .messageContent {
+    font-size: 15px;
+    line-height: 1.5;
+  }
+
+  .messageInput {
+    font-size: 16px; /* Prevents zoom on iOS Safari */
+    line-height: 1.4;
+  }
+}
+
+/* Additional constraints for very small screens or when keyboard is active */
+@media (max-width: 768px) and (max-height: 500px) {
+  .chatContainer {
+    /* When height is very constrained, use most of available space */
+    height: calc(100dvh - 120px);
+    min-height: 250px;
+    max-height: calc(100dvh - 120px);
+  }
+
+  .messagesContainer {
+    padding: 8px;
+  }
+
+  .inputForm {
+    padding: 8px;
   }
 }
 

--- a/src/components/chat/FloatingChatWidget.tsx
+++ b/src/components/chat/FloatingChatWidget.tsx
@@ -3,7 +3,6 @@
 import React, { useState, useRef, useEffect } from 'react';
 import { createPortal } from 'react-dom';
 import {
-  HiChevronUp,
   HiXMark,
   HiPaperAirplane,
   HiChatBubbleLeftRight,
@@ -224,17 +223,15 @@ export default function FloatingChatWidget({
         </div>
       )}
 
-      <button
-        onClick={toggleChat}
-        className={`${styles.chatToggle} ${isOpen ? styles.chatToggleOpen : ''}`}
-        aria-label={isOpen ? 'Close chat' : 'Open chat'}
-      >
-        {isOpen ? (
-          <HiChevronUp className={styles.toggleIcon} />
-        ) : (
+      {!isOpen && (
+        <button
+          onClick={toggleChat}
+          className={styles.chatToggle}
+          aria-label="Open chat"
+        >
           <HiChatBubbleLeftRight className={styles.chatIcon} />
-        )}
-      </button>
+        </button>
+      )}
 
       {!isOpen && showPrompt && (
         <div className={styles.chatPrompt}>


### PR DESCRIPTION
This PR fixes the AI Chat widget for mobile responsiveness and removes the chat toggle button when the conversation is open. This was particularly necessary because the chat window on phones (while the keyboard is open) is quite small. This PR accounts for that and makes sure users are still able to read responses and make use of the screen with their keyboard open. 
This also hides the chat toggle button when the conversation is open rather than having it open below it, which causes layout problems. 