### PR TITLE
Fix/work page mobile prompt text

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@ node_modules
 # testing
 /coverage
 
+# mcp
+/.playwright-mcp
+
 # next.js
 /.next/
 /out/

--- a/SESSION_LOG.md
+++ b/SESSION_LOG.md
@@ -75,7 +75,7 @@
 
 3. **Commits Created**
    - `e0f79c2`: ✨ feat(chat): enhance RAG chat with suggested questions and improved UX
-   - `b38d568`: 📝 refactor(knowledge): optimize knowledge base files for RAG retrieval  
+   - `b38d568`: 📝 refactor(knowledge): optimize knowledge base files for RAG retrieval
    - `99ad744`: 🔖 chore: bump version to 2.5.1 and update documentation
    - `863654a`: Add Turing description
    - `718b535`: Add general accident description
@@ -139,7 +139,7 @@ git branch -d feature/rag-chat-improvements
 ## Outstanding Tasks
 
 1. Monitor RAG chat performance with new suggested questions feature
-2. Test knowledge base embedding reprocessing for optimization benefits  
+2. Test knowledge base embedding reprocessing for optimization benefits
 3. Consider analytics tracking for suggested question usage
 4. Plan next phase enhancements based on user feedback
 
@@ -1366,4 +1366,3 @@ Based on recent commits, significant progress on **Phase 2: Blog Creation Interf
 2. Consider performance impact of layout changes
 3. Plan next content updates based on job search progress
 4. Monitor SEO improvements from metadata enhancements
-

--- a/src/app/components/job.module.css
+++ b/src/app/components/job.module.css
@@ -139,14 +139,18 @@
     grid-template-columns: 1fr;
   }
 
+  .jobImage {
+    display: flex;
+    justify-content: center;
+  }
+
   .jobTitle {
     flex-direction: column;
   }
 
   .companyLogo {
-    display: flex;
-    justify-content: center;
     margin: 0;
+    width: 3rem;
     height: 3rem;
   }
 }

--- a/src/components/chat/FloatingChatWidget.module.css
+++ b/src/components/chat/FloatingChatWidget.module.css
@@ -7,7 +7,7 @@
     --ff-primary,
     -apple-system,
     BlinkMacSystemFont,
-    "Segoe UI",
+    'Segoe UI',
     Roboto,
     sans-serif
   );
@@ -504,10 +504,10 @@
   /* No animations on the button itself - animations are now on pseudo-elements */
 }
 
-.chatToggle:hover {
+/* .chatToggle:hover {
   transform: scale(1.05);
   box-shadow: 0 0.375rem 1.25rem rgba(0, 0, 0, 0.2);
-}
+} */
 
 .chatToggle:active {
   transform: scale(0.95);
@@ -521,23 +521,49 @@
   transform: scale(1.3);
 }
 
+/* Chat prompt styles - desktop */
+.chatPrompt {
+  position: absolute;
+  bottom: 150px;
+  right: 0;
+  background: rgba(var(--theme-color-rgb, 26, 107, 138), 0.15);
+  backdrop-filter: blur(1rem);
+  -webkit-backdrop-filter: blur(1rem);
+  border: 2px solid rgba(var(--clr-neutral-400-rgb, 102, 102, 102), 0.4);
+  border-radius: 1rem;
+  padding: 1.25rem 1.5rem;
+  box-shadow:
+    0 0.5rem 1.5rem rgba(0, 0, 0, 0.1),
+    0 0 1.25rem rgba(var(--theme-color-rgb, 26, 107, 138), 0.2),
+    inset 0 1px 0 rgba(255, 255, 255, 0.1);
+  white-space: nowrap;
+  animation:
+    promptFadeIn 0.3s ease-out,
+    promptBounce 2s infinite ease-in-out;
+  animation-delay: 0s, 1s;
+  max-width: 28rem;
+  z-index: 1002;
+}
+
 /* Responsive adjustments */
-@media (max-width: 768px) {
+@media (max-width: 769px) {
   .chatWidget {
     bottom: 1rem;
     right: 1rem;
+    left: auto;
   }
 
   .chatContainer {
-    width: calc(100vw - 2rem);
-    /* Use dvh for dynamic viewport height that accounts for mobile keyboard */
-    height: min(60dvh, 28.125rem);
-    /* Ensure minimum usable height even when keyboard is active */
-    min-height: 18.75rem;
-    /* Use max for better constraint */
-    max-height: min(60dvh, 28.125rem);
-    bottom: 4.375rem;
-    right: 0;
+    width: calc(100vw - 1rem);
+    height: auto;
+    max-height: none;
+    min-height: 25rem;
+    position: fixed;
+    top: 0.5rem;
+    bottom: 0.5rem;
+    right: 0.5rem;
+    left: 0.5rem;
+    border-radius: 1rem;
   }
 
   .chatToggle {
@@ -579,12 +605,13 @@
 
   /* Adjust chat prompt positioning for mobile */
   .chatPrompt {
-    position: absolute;
-    bottom: 4.5rem;
-    left: -10.375rem;
+    position: fixed;
+    bottom: 5.5rem;
+    right: 1rem;
+    left: auto;
     white-space: normal;
     text-align: center;
-    padding: 1.25rem 1.5rem;
+    padding: 1rem;
     background: rgba(var(--theme-color-rgb, 26, 107, 138), 0.15);
     backdrop-filter: blur(1rem);
     -webkit-backdrop-filter: blur(1rem);
@@ -594,7 +621,7 @@
       0 0.5rem 1.5rem rgba(0, 0, 0, 0.1),
       0 0 1.25rem rgba(var(--theme-color-rgb, 26, 107, 138), 0.2),
       inset 0 1px 0 rgba(255, 255, 255, 0.1);
-    transform-origin: center right;
+    transform-origin: center bottom;
     pointer-events: auto;
     opacity: 1;
     z-index: 1002;
@@ -602,7 +629,6 @@
       promptFadeIn 0.3s ease-out,
       promptBounce 2s infinite ease-in-out;
     animation-delay: 0s, 1s;
-    width: calc(100vw - 8rem);
   }
 
   .promptText {
@@ -615,8 +641,7 @@
   .promptArrow {
     position: absolute;
     bottom: -0.75rem;
-    right: 50%;
-    transform: translateX(50%);
+    right: 1rem;
     width: 0;
     height: 0;
     border-left: 0.75rem solid transparent;
@@ -626,7 +651,7 @@
   }
 
   .promptArrow::before {
-    content: "";
+    content: '';
     position: absolute;
     bottom: 2px;
     left: -0.6875rem;
@@ -641,19 +666,33 @@
   .greetingBubble {
     top: 40vh;
     right: 1rem;
-    left: 1rem;
+    left: auto;
     max-width: calc(100vw - 2rem);
     transform: translateY(-50%);
   }
 }
 
 /* Additional constraints for very small screens or when keyboard is active */
-@media (max-width: 768px) and (max-height: 500px) {
+@media (max-width: 769px) and (max-height: 500px) {
   .chatContainer {
     /* When height is very constrained, use most of available space */
-    height: calc(100dvh - 7.5rem);
-    min-height: 15.625rem;
-    max-height: calc(100dvh - 7.5rem);
+    height: auto;
+    min-height: 12.5rem;
+    max-height: 18rem;
+    top: 0.5rem;
+    bottom: 0.5rem;
+    left: 50%;
+    right: auto;
+    transform: translateX(-50%);
+  }
+
+  .chatHeader {
+    padding: 1rem;
+    border-radius: 1rem 1rem 0 0;
+  }
+
+  .chatHeader h3 {
+    font-size: var(--fs-400);
   }
 
   .messagesContainer {
@@ -662,6 +701,21 @@
 
   .inputForm {
     padding: 0.5rem;
+  }
+
+  .welcomeMessage {
+    padding: 0.5rem;
+    font-size: var(--fs-200);
+  }
+
+  .suggestedQuestions {
+    margin-top: 0.5rem;
+    gap: 0.375rem;
+  }
+
+  .suggestionButton {
+    padding: 0.375rem 0.5rem;
+    font-size: var(--fs-100);
   }
 }
 
@@ -703,7 +757,7 @@
 }
 
 .chatToggle::before {
-  content: "";
+  content: '';
   position: absolute;
   top: 0;
   left: -100%;
@@ -718,30 +772,6 @@
   animation: chatShine 3s infinite linear;
 }
 
-/* Chat prompt styles - desktop */
-.chatPrompt {
-  position: absolute;
-  bottom: 150px;
-  right: 0;
-  background: rgba(var(--theme-color-rgb, 26, 107, 138), 0.15);
-  backdrop-filter: blur(1rem);
-  -webkit-backdrop-filter: blur(1rem);
-  border: 2px solid rgba(var(--clr-neutral-400-rgb, 102, 102, 102), 0.4);
-  border-radius: 1rem;
-  padding: 1.25rem 1.5rem;
-  box-shadow:
-    0 0.5rem 1.5rem rgba(0, 0, 0, 0.1),
-    0 0 1.25rem rgba(var(--theme-color-rgb, 26, 107, 138), 0.2),
-    inset 0 1px 0 rgba(255, 255, 255, 0.1);
-  white-space: nowrap;
-  animation:
-    promptFadeIn 0.3s ease-out,
-    promptBounce 2s infinite ease-in-out;
-  animation-delay: 0s, 1s;
-  max-width: 28rem;
-  z-index: 1002;
-}
-
 .promptText {
   font-size: var(--fs-700);
   font-weight: 500;
@@ -750,20 +780,22 @@
   user-select: none;
 }
 
-.promptArrow {
-  position: absolute;
-  bottom: -0.75rem;
-  right: 50%;
-  transform: translateX(50%);
-  width: 0;
-  height: 0;
-  border-left: 0.75rem solid transparent;
-  border-right: 0.75rem solid transparent;
-  border-top: 0.75rem solid rgba(var(--clr-neutral-400-rgb, 102, 102, 102), 0.4);
+@media (min-width: 770px) {
+  .promptArrow {
+    position: absolute;
+    bottom: -0.75rem;
+    right: 3rem;
+    width: 0;
+    height: 0;
+    border-left: 0.75rem solid transparent;
+    border-right: 0.75rem solid transparent;
+    border-top: 0.75rem solid
+      rgba(var(--clr-neutral-400-rgb, 102, 102, 102), 0.4);
+  }
 }
 
 .promptArrow::before {
-  content: "";
+  content: '';
   position: absolute;
   bottom: 2px;
   left: -0.6875rem;
@@ -832,8 +864,8 @@
 /* Greeting bubble styles */
 .greetingBubble {
   position: absolute;
-  top: 50vh;
-  right: 1.5rem;
+  top: 40vh;
+  left: 2.5rem;
   background: rgba(var(--theme-color-rgb, 26, 107, 138), 0.15);
   backdrop-filter: blur(1rem);
   -webkit-backdrop-filter: blur(1rem);
@@ -909,7 +941,7 @@
 }
 
 .greetingArrow::before {
-  content: "";
+  content: '';
   position: absolute;
   bottom: 2px;
   left: -0.375rem;
@@ -957,7 +989,7 @@
 
 /* Add shimmer effect inside the bubble */
 .greetingBubble::before {
-  content: "";
+  content: '';
   position: absolute;
   top: 0;
   left: -100%;

--- a/src/components/chat/FloatingChatWidget.module.css
+++ b/src/components/chat/FloatingChatWidget.module.css
@@ -7,7 +7,7 @@
     --ff-primary,
     -apple-system,
     BlinkMacSystemFont,
-    'Segoe UI',
+    "Segoe UI",
     Roboto,
     sans-serif
   );
@@ -579,21 +579,62 @@
 
   /* Adjust chat prompt positioning for mobile */
   .chatPrompt {
-    bottom: 5rem;
-    left: 1rem;
-    right: 1rem;
-    max-width: none;
-    width: calc(100vw - 2rem);
-    white-space: normal; /* Allow text wrapping on mobile */
-    text-align: center; /* Center the text */
-    padding: 0.5rem 0.75rem; /* Reduce padding on mobile */
+    position: absolute;
+    bottom: 4.5rem;
+    left: -10.375rem;
+    white-space: normal;
+    text-align: center;
+    padding: 1.25rem 1.5rem;
+    background: rgba(var(--theme-color-rgb, 26, 107, 138), 0.15);
+    backdrop-filter: blur(1rem);
+    -webkit-backdrop-filter: blur(1rem);
+    border: 2px solid rgba(var(--clr-neutral-400-rgb, 102, 102, 102), 0.4);
+    border-radius: 1rem;
+    box-shadow:
+      0 0.5rem 1.5rem rgba(0, 0, 0, 0.1),
+      0 0 1.25rem rgba(var(--theme-color-rgb, 26, 107, 138), 0.2),
+      inset 0 1px 0 rgba(255, 255, 255, 0.1);
+    transform-origin: center right;
+    pointer-events: auto;
+    opacity: 1;
+    z-index: 1002;
+    animation:
+      promptFadeIn 0.3s ease-out,
+      promptBounce 2s infinite ease-in-out;
+    animation-delay: 0s, 1s;
+    width: calc(100vw - 8rem);
   }
 
   .promptText {
-    font-size: var(--fs-400); /* Even smaller font size on mobile */
+    font-size: var(--fs-400);
     line-height: 1.2;
     font-weight: 500;
     user-select: none;
+  }
+
+  .promptArrow {
+    position: absolute;
+    bottom: -0.75rem;
+    right: 50%;
+    transform: translateX(50%);
+    width: 0;
+    height: 0;
+    border-left: 0.75rem solid transparent;
+    border-right: 0.75rem solid transparent;
+    border-top: 0.75rem solid
+      rgba(var(--clr-neutral-400-rgb, 102, 102, 102), 0.4);
+  }
+
+  .promptArrow::before {
+    content: "";
+    position: absolute;
+    bottom: 2px;
+    left: -0.6875rem;
+    width: 0;
+    height: 0;
+    border-left: 0.6875rem solid transparent;
+    border-right: 0.6875rem solid transparent;
+    border-top: 0.6875rem solid rgba(var(--theme-color-rgb, 26, 107, 138), 0.15);
   }
 
   /* Adjust greeting bubble positioning for mobile */
@@ -645,8 +686,8 @@
 }
 
 .chatIcon {
-  width: 3rem;
-  height: 3rem;
+  width: 2.5rem;
+  height: 2.5rem;
   color: var(--text-primary);
   animation: chatIconPulse 3s infinite ease-in-out;
 }
@@ -662,7 +703,7 @@
 }
 
 .chatToggle::before {
-  content: '';
+  content: "";
   position: absolute;
   top: 0;
   left: -100%;
@@ -677,23 +718,26 @@
   animation: chatShine 3s infinite linear;
 }
 
-/* Chat prompt styles */
+/* Chat prompt styles - desktop */
 .chatPrompt {
   position: absolute;
   bottom: 150px;
   right: 0;
-  background: var(--background-primary);
-  border: 1px solid var(--theme-color);
-  border-radius: var(--border-radius);
-  padding: 0.75rem 1rem;
-  box-shadow: 0 0.25rem 1rem rgba(0, 0, 0, 0.1);
+  background: rgba(var(--theme-color-rgb, 26, 107, 138), 0.15);
+  backdrop-filter: blur(1rem);
+  -webkit-backdrop-filter: blur(1rem);
+  border: 2px solid rgba(var(--clr-neutral-400-rgb, 102, 102, 102), 0.4);
+  border-radius: 1rem;
+  padding: 1.25rem 1.5rem;
+  box-shadow:
+    0 0.5rem 1.5rem rgba(0, 0, 0, 0.1),
+    0 0 1.25rem rgba(var(--theme-color-rgb, 26, 107, 138), 0.2),
+    inset 0 1px 0 rgba(255, 255, 255, 0.1);
   white-space: nowrap;
   animation:
     promptFadeIn 0.3s ease-out,
     promptBounce 2s infinite ease-in-out;
   animation-delay: 0s, 1s;
-  backdrop-filter: blur(10px);
-  -webkit-backdrop-filter: blur(10px);
   max-width: 28rem;
   z-index: 1002;
 }
@@ -708,25 +752,26 @@
 
 .promptArrow {
   position: absolute;
-  bottom: -0.375rem;
-  right: 1.25rem;
+  bottom: -0.75rem;
+  right: 50%;
+  transform: translateX(50%);
   width: 0;
   height: 0;
-  border-left: 0.375rem solid transparent;
-  border-right: 0.375rem solid transparent;
-  border-top: 0.375rem solid var(--border-color);
+  border-left: 0.75rem solid transparent;
+  border-right: 0.75rem solid transparent;
+  border-top: 0.75rem solid rgba(var(--clr-neutral-400-rgb, 102, 102, 102), 0.4);
 }
 
 .promptArrow::before {
-  content: '';
+  content: "";
   position: absolute;
-  bottom: 1px;
-  left: -5px;
+  bottom: 2px;
+  left: -0.6875rem;
   width: 0;
   height: 0;
-  border-left: 5px solid transparent;
-  border-right: 5px solid transparent;
-  border-top: 5px solid var(--background-primary);
+  border-left: 0.6875rem solid transparent;
+  border-right: 0.6875rem solid transparent;
+  border-top: 0.6875rem solid rgba(var(--theme-color-rgb, 26, 107, 138), 0.15);
 }
 
 /* Waving animation for the chat button */
@@ -864,7 +909,7 @@
 }
 
 .greetingArrow::before {
-  content: '';
+  content: "";
   position: absolute;
   bottom: 2px;
   left: -0.375rem;
@@ -912,7 +957,7 @@
 
 /* Add shimmer effect inside the bubble */
 .greetingBubble::before {
-  content: '';
+  content: "";
   position: absolute;
   top: 0;
   left: -100%;

--- a/src/components/chat/FloatingChatWidget.tsx
+++ b/src/components/chat/FloatingChatWidget.tsx
@@ -291,7 +291,7 @@ export default function FloatingChatWidget({
 
       {!isOpen && showPrompt && (
         <div className={styles.chatPrompt}>
-          <div className={styles.promptText}>Ask me (AI) about Zach</div>
+          <div className={styles.promptText}>Ask AI about Zach</div>
           <div className={styles.promptArrow}></div>
         </div>
       )}

--- a/src/data/knowledge/professional.md
+++ b/src/data/knowledge/professional.md
@@ -157,23 +157,27 @@ Zach Liibbe is currently unemployed and actively seeking new opportunities as of
 **Status:** Program completed successfully (school has since closed)
 
 **Curriculum Structure:**
+
 - Module-based learning: 4 six-week modules plus preparatory Module 0
 - Project-based learning approach with hands-on application development
 - Module 4: Full-stack collaboration project combining front-end and back-end students
 
 **Technologies & Skills Learned:**
+
 - **Core Frontend:** HTML5, CSS3, JavaScript (ES6+), responsive design
-- **Frameworks & Libraries:** React, Redux, Node.js for full-stack applications  
+- **Frameworks & Libraries:** React, Redux, Node.js for full-stack applications
 - **Development Tools:** Git/GitHub, testing frameworks, CI/CD practices
 - **Professional Development:** Technical interview preparation, portfolio development, career coaching
 
 **Key Projects & Achievements:**
+
 - Built multiple responsive web applications using React and vanilla JavaScript
 - Collaborated on full-stack applications with backend engineering students
 - Developed strong problem-solving methodology through structured curriculum
 - Completed intensive technical interview and job search preparation program
 
 **Program Impact:**
+
 - Transitioned from healthcare to software engineering through rigorous technical training
 - Developed foundational skills that enabled successful career pivot
 - Gained collaborative development experience working with diverse technical teams


### PR DESCRIPTION
 Summary

  Fixed CSS cascade issues causing desktop chat prompt arrow styles to override mobile styles at the 768px breakpoint. This
   ensures the chat prompt arrow correctly points to the center of the chat toggle button on tablet and mobile devices.

  Changes Made

  - Mobile media query breakpoint: Changed from max-width: 768px to max-width: 769px to ensure proper inclusion
  - Desktop .promptArrow styles: Wrapped in @media (min-width: 770px) to prevent override at mobile breakpoints
  - Mobile .promptArrow positioning: Set to right: 1rem to center arrow over chat toggle button (3.5rem wide)
  - Mobile .greetingBubble positioning: Fixed left: auto to keep bubble on right side of screen
  - Mobile .chatPrompt positioning: Fixed left: auto to prevent stretching across screen

  Problem

  At 768px width, the desktop .promptArrow styles (defined outside media queries) were overriding the mobile styles due to
  CSS cascade order. This caused the arrow to appear at right: 3rem instead of the intended mobile position.

  Solution

  Restructured CSS to use complementary media queries:
  - Mobile: @media (max-width: 769px) with right: 1rem
  - Desktop: @media (min-width: 770px) with right: 3rem

  This ensures clean breakpoint separation and proper style application at exactly 768px width.

  Testing

  Verified with Playwright at 768px, 1024px, and smaller screen sizes to ensure cohesive chat widget appearance across all
  breakpoints.