### PR TITLE
Fix/activities multi day display

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,30 @@
 # Zach Liibbe's Personal Website
 
-A modern [Next.js](https://nextjs.org/) 15 portfolio website with integrated blog system, activity tracking, and admin dashboard. Built with the App Router and deployed on Vercel at [zachliibbe.com](https://www.zachliibbe.com/).
+A modern [Next.js](https://nextjs.org/) 15 portfolio website with RAG-powered AI chat, integrated blog system, activity tracking, and comprehensive admin dashboard. Built with the App Router and deployed on Vercel at [zachliibbe.com](https://www.zachliibbe.com/).
 
 ## Features
+
+### 🤖 **RAG-Powered AI Chat System**
+
+- **Intelligent Conversational AI** - Claude-powered chat widget for visitor engagement
+- **Semantic Search** - Pinecone vector database with 81 knowledge vectors
+- **Context-Aware Responses** - RAG (Retrieval Augmented Generation) for accurate information
+- **Cost-Optimized** - Adaptive model selection (Haiku/Sonnet) based on query complexity
+- **Rate Limiting** - 100 requests per IP per day with persistent tracking via Vercel KV
+- **Knowledge Base Management** - Admin interface for real-time knowledge updates and testing
+- **Session Management** - 10-message limit per session for cost control
+
+### 📝 **Blog Management System**
+
+- **Full Blog CMS** - Create, edit, and manage blog posts with markdown editor
+- **Post Scheduling** - Schedule posts for future publication with automated publishing via cron jobs
+- **Draft Management** - Save drafts with auto-save functionality
+- **Rich Content** - Support for categories, tags, series, and featured images from Unsplash
+- **SEO Preview** - Google search result and social media card previews
+- **Reading Progress** - Sticky progress bar tracking scroll position
+- **Blog Search** - Full-text search across titles, excerpts, categories, and tags
+- **LinkedIn Cross-posting** - One-click LinkedIn post generation with 28 engagement templates
+- **RSS Feed** - Automatically generated RSS feed for blog content
 
 ### 🎨 **Customizable Theme System**
 
@@ -11,35 +33,43 @@ A modern [Next.js](https://nextjs.org/) 15 portfolio website with integrated blo
 - **Animation Controls** - Enable/disable gradient animations based on user preference
 - **Persistent Settings** - All preferences saved to localStorage for consistent experience
 
-### 📝 **Blog Management System**
-
-- **Full Blog CMS** - Create, edit, and manage blog posts with markdown editor
-- **Post Scheduling** - Schedule posts for future publication with automated publishing via cron jobs
-- **Draft Management** - Save drafts with auto-save functionality
-- **Rich Content** - Support for categories, tags, series, and featured images from Unsplash
-- **RSS Feed** - Automatically generated RSS feed for blog content
-
 ### 🔐 **Admin Dashboard**
 
 - **Google OAuth Authentication** - Secure admin access with NextAuth.js
 - **Protected Routes** - Session-based route protection for admin functionality
-- **Blog Administration** - Complete interface for content management
+- **Blog Administration** - Complete interface for content management with live preview
+- **Knowledge Base Editor** - Real-time markdown editing with change detection
+- **Performance Monitoring** - Cache statistics and embedding status dashboard
+- **RAG Testing Interface** - Query testing with context visualization and relevance scoring
 - **Unsplash Integration Management** - Monitor API usage and status
 
 ### 📊 **Activity & Data Integration**
 
 - **Strava Integration** - Display latest fitness activities with OAuth token management
-- **Goodreads Integration** - Show currently reading books and reading progress
+- **Multi-Activity Heatmap** - Calendar visualization with diagonal split squares for multi-activity days
+- **Activity Stats Cards** - Hover/touch preview with detailed metrics (distance, pace, elevation)
+- **Goodreads Integration** - Show currently reading books with progress tracking
+- **Book Cover Previews** - Hover/touch to display book covers in footer
 - **Automated Caching** - Intelligent caching with Vercel KV for optimal performance
 - **Real-time Updates** - Live data feeds with configurable refresh intervals
 
+### 📈 **Analytics & Performance**
+
+- **Google Analytics 4** - Comprehensive event tracking across all interactions
+- **Blog Post Tracking** - View counts, read completion (90% scroll), and social shares
+- **Chat Analytics** - Open/close events, message counts, and session duration
+- **Search & Filter Tracking** - User search queries and filter selections
+- **Vercel Speed Insights** - Real-time Core Web Vitals monitoring (LCP, FID, CLS)
+- **Performance Optimization** - Persistent rate limiting and adaptive caching strategies
+
 ### 🚀 **Performance & Infrastructure**
 
-- **Next.js 15 App Router** - Modern React architecture with server-side rendering
-- **Vercel KV Storage** - Edge-compatible caching and data persistence
+- **Next.js 15.5.4** - Latest React framework with App Router and RSC
+- **React 19** - Latest React with improved performance and features
+- **Vercel KV Storage** - Edge-compatible Redis for caching and data persistence
 - **Image Optimization** - Next.js Image component with multiple CDN sources
-- **TypeScript** - Full type safety with strict configuration
-- **Responsive Design** - Mobile-first design with CSS Modules
+- **TypeScript** - Full type safety with strict configuration and ESLint CLI
+- **Responsive Design** - Mobile-first design with CSS Modules and custom properties
 
 ## 🚀 Getting Started
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
         "@vercel/kv": "^3.0.0",
+        "@vercel/speed-insights": "^1.2.0",
         "eslint": "^9.29.0",
         "eslint-config-next": "^15.1.0",
         "eslint-plugin-prettier": "^5.2.3",
@@ -3192,6 +3193,41 @@
       },
       "engines": {
         "node": ">=14.6"
+      }
+    },
+    "node_modules/@vercel/speed-insights": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@vercel/speed-insights/-/speed-insights-1.2.0.tgz",
+      "integrity": "sha512-y9GVzrUJ2xmgtQlzFP2KhVRoCglwfRQgjyfY607aU0hh0Un6d0OUyrJkjuAlsV18qR4zfoFPs/BiIj9YDS6Wzw==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
       }
     },
     "node_modules/abab": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portfolio",
-  "version": "2.7.0",
+  "version": "2.8.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "@vercel/kv": "^3.0.0",
+    "@vercel/speed-insights": "^1.2.0",
     "eslint": "^9.29.0",
     "eslint-config-next": "^15.1.0",
     "eslint-plugin-prettier": "^5.2.3",

--- a/src/app/components/ActivityGrid.tsx
+++ b/src/app/components/ActivityGrid.tsx
@@ -159,7 +159,7 @@ export default function ActivityGrid({ activities }: ActivityGridProps) {
 
         // Check if this square represents a multi-activity day by looking at its title
         const title = (rect.querySelector('title')?.textContent || '').trim();
-        const isMultiActivity = title.includes('recorded activities on');
+        const isMultiActivity = title.includes('activities on');
 
         if (isMultiActivity && rect.parentElement) {
           // Extract the date from the title

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -10,6 +10,7 @@ import Analytics from './components/Analytics';
 import AuthProvider from '@/lib/auth-provider';
 import ChatProvider from '@/components/chat/ChatProvider';
 import { ErrorBoundary } from '@/components/ErrorBoundary';
+import { SpeedInsights } from '@vercel/speed-insights/next';
 
 const robotoMono = Roboto_Mono({
   subsets: ['latin'],
@@ -154,6 +155,7 @@ export default function RootLayout({
                 <Header />
                 <ErrorBoundary resetOnPropsChange={true}>
                   {children}
+                  <SpeedInsights />
                 </ErrorBoundary>
               </div>
               <ChatProvider />


### PR DESCRIPTION
## Summary

  Fixes the activity grid display bug where multi-activity days were showing as black squares instead of diagonal color
  splits. This PR also includes documentation updates and Vercel Speed Insights integration.

  ## Changes

  ### 🐛 Bug Fix: Multi-Activity Day Display
  - **Problem**: Days with multiple activities (e.g., run + weight training) displayed as solid black squares instead of
  diagonal splits with appropriate colors
  - **Root Cause**: The useEffect hook was checking for `'recorded activities on'` in the title text, but the actual format
   is `'activities on'` (e.g., "2 activities on January 10, 2025")
  - **Solution**: Updated title matching logic in `ActivityGrid.tsx` to correctly detect multi-activity days
  - **Impact**: Multi-activity days now properly render with diagonal color splits showing both activity types

  ### 📈 Feature: Vercel Speed Insights
  - Integrated `@vercel/speed-insights` for Core Web Vitals monitoring
  - Added SpeedInsights component to root layout
  - Tracks LCP, FID, CLS metrics in production

  ### 📝 Documentation: README Enhancement
  - Comprehensive update to README.md with all current features
  - Added detailed sections for RAG-powered AI chat, blog system, analytics, and admin dashboard
  - Updated tech stack and API routes documentation

  ## Testing

  - ✅ Verified multi-activity days now display with correct diagonal color splits
  - ✅ Confirmed Speed Insights loads correctly in development mode
  - ✅ All existing functionality remains intact

  ## Related

  Closes Phase 12 from PRD.md - Fix Activities Display for Multiple Activities Per Day