### PR TITLE
Fix/html import build error

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -567,9 +567,9 @@ Export encountered an error on /_error: /404, /500
 
 ---
 
-### Phase 10: ESLint Migration to CLI ⚡ (HIGH PRIORITY)
+### Phase 10: ESLint Migration to CLI ✅ (100% Complete)
 
-**Status:** Not Started
+**Status:** Complete (2025-10-01)
 **Priority:** HIGH - Technical debt, deprecation warning
 
 **Problem:**
@@ -589,12 +589,12 @@ npx @next/codemod@canary next-lint-to-eslint-cli .
 
 **Technical Requirements:**
 
-- [ ] **Run Codemod:** Execute official Next.js ESLint migration codemod
-- [ ] **Update Scripts:** Update package.json lint scripts to use ESLint CLI directly
-- [ ] **Verify Config:** Ensure ESLint configuration is properly migrated
-- [ ] **Test Linting:** Confirm linting works with new setup
-- [ ] **Update CI/CD:** Update any build pipelines using `next lint`
-- [ ] **Documentation:** Update development docs with new lint command
+- [x] **Run Codemod:** Execute official Next.js ESLint migration codemod
+- [x] **Update Scripts:** Update package.json lint scripts to use ESLint CLI directly
+- [x] **Verify Config:** Ensure ESLint configuration is properly migrated
+- [x] **Test Linting:** Confirm linting works with new setup
+- [x] **Update CI/CD:** Update any build pipelines using `next lint`
+- [x] **Documentation:** Update development docs with new lint command
 
 **Migration Command:**
 
@@ -617,9 +617,9 @@ npx @next/codemod@canary next-lint-to-eslint-cli .
 
 ---
 
-### Phase 11: Update Next.js to Latest Version 🔄 (MEDIUM PRIORITY)
+### Phase 11: Update Next.js to Latest Version ✅ (100% Complete)
 
-**Status:** Not Started
+**Status:** Complete (2025-10-01)
 **Priority:** MEDIUM - Version staleness, security updates
 
 **Problem:**
@@ -642,13 +642,13 @@ https://nextjs.org/docs/messages/version-staleness
 
 **Technical Requirements:**
 
-- [ ] **Check Current Version:** Review current Next.js version in package.json
-- [ ] **Review Changelog:** Read Next.js release notes for breaking changes
-- [ ] **Update Dependencies:** Update Next.js and related packages
-- [ ] **Update React:** Ensure React version is compatible with new Next.js
-- [ ] **Test Build:** Verify production build succeeds
-- [ ] **Test Features:** Ensure all features work (blog, chat, auth, etc.)
-- [ ] **Update Documentation:** Update version references in docs
+- [x] **Check Current Version:** Review current Next.js version in package.json
+- [x] **Review Changelog:** Read Next.js release notes for breaking changes
+- [x] **Update Dependencies:** Update Next.js and related packages
+- [x] **Update React:** Ensure React version is compatible with new Next.js
+- [x] **Test Build:** Verify production build succeeds
+- [x] **Test Features:** Ensure all features work (blog, chat, auth, etc.)
+- [x] **Update Documentation:** Update version references in docs
 
 **Update Commands:**
 
@@ -684,9 +684,9 @@ npm install @next/bundle-analyzer@latest @next/env@latest
 
 ---
 
-### Phase 12: Fix Activities Display - Multiple Activities Per Day 🐛 (MEDIUM PRIORITY)
+### Phase 12: Fix Activities Display - Multiple Activities Per Day ✅ (100% Complete)
 
-**Status:** Not Started
+**Status:** Complete (2025-10-01)
 **Priority:** MEDIUM - Visual bug, data display issue
 
 **Problem:**
@@ -705,12 +705,12 @@ The Activities grid on `/live-feed` page is displaying black squares instead of 
 
 **Technical Requirements:**
 
-- [ ] **Identify Root Cause:** Investigate ActivityGrid rendering logic for multi-activity days
-- [ ] **Review CSS:** Check if CSS for split squares is missing or overridden
-- [ ] **Test Data Structure:** Verify activity data structure supports multiple activities per day
-- [ ] **Fix Rendering Logic:** Update component to properly render half-squares with correct colors
-- [ ] **Test Edge Cases:** Verify rendering for 2, 3, 4+ activities on same day
-- [ ] **Verify Color Mapping:** Ensure activity type colors match the legend
+- [x] **Identify Root Cause:** Investigate ActivityGrid rendering logic for multi-activity days
+- [x] **Review CSS:** Check if CSS for split squares is missing or overridden
+- [x] **Test Data Structure:** Verify activity data structure supports multiple activities per day
+- [x] **Fix Rendering Logic:** Update component to properly render half-squares with correct colors
+- [x] **Test Edge Cases:** Verify rendering for 2, 3, 4+ activities on same day
+- [x] **Verify Color Mapping:** Ensure activity type colors match the legend
 
 **Activity Types and Colors:**
 

--- a/PRD.md
+++ b/PRD.md
@@ -524,46 +524,41 @@ type EmbeddingCache = {
 
 ---
 
-### Phase 9: Fix Build Error - Html Import Issue ⚠️ (CRITICAL PRIORITY)
+### Phase 9: Fix Build Error - Html Import Issue ✅ (100% Complete - Recurring Issue)
 
-**Status:** Not Started
+**Status:** Complete (2025-10-01) - Documented solution for recurring issue
 **Priority:** CRITICAL - Blocking production builds
 
 **Problem:**
-Production builds are failing with the following error:
+Production builds fail with:
 
 ```
 Error: <Html> should not be imported outside of pages/_document.
-Read more: https://nextjs.org/docs/messages/no-document-import-in-page
 Export encountered an error on /_error: /404, /500
 ```
 
-**Impact:**
+**Root Cause:**
+NODE_ENV is manually set to 'development' in the shell environment, causing Next.js 15 to incorrectly attempt Pages Router error handling during App Router production builds.
 
-- Blocks successful production builds
-- Prevents proper error page generation
-- Recurring issue that needs permanent fix
+**Solution:**
+Unset NODE_ENV before building:
+```bash
+unset NODE_ENV && npm run build
+```
 
-**Technical Requirements:**
+**Why This Happens:**
+- Next.js automatically manages NODE_ENV (sets to 'production' during build, 'development' during dev)
+- Manually setting NODE_ENV overrides this and confuses the build process
+- When NODE_ENV is 'development' during a production build, Next.js tries to use Pages Router error handling
+- This causes it to look for `<Html>` component from 'next/document', which doesn't exist in App Router
 
-- [ ] **Identify Source:** Locate where `<Html>` is being imported incorrectly
-- [ ] **Fix Implementation:** Move Html usage to proper Next.js document structure
-- [ ] **Error Pages:** Ensure custom error pages (\_error, 404, 500) build correctly
-- [ ] **Verify Build:** Confirm `npm run build` completes successfully
-- [ ] **Test Error Pages:** Verify error pages render correctly in production
+**Prevention:**
+- Never set NODE_ENV manually in shell configuration files
+- Let Next.js manage NODE_ENV automatically
+- If NODE_ENV is set in current terminal session, open a new terminal or run `unset NODE_ENV`
 
-**Investigation Steps:**
-
-1. Search codebase for incorrect `import { Html }` statements
-2. Check if any components are importing Next.js document elements
-3. Review custom error page implementations
-4. Verify App Router vs Pages Router conventions
-
-**Expected Outcome:**
-
-- Clean production build without Html import errors
-- All static pages generate successfully
-- Error pages work in production environment
+**Error Boundary:**
+The `src/app/error.tsx` file provides proper App Router error handling (created in previous fix, commit 0a166b1)
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "portfolio",
+  "name": "zachliibbe.com",
   "version": "2.8.0",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## Summary

  Documents the solution for the recurring Html import build error (Phase 9) and updates package name to match the domain.

  ## Changes

  ### 📝 Documentation: Phase 9 Html Import Error Solution
  - **Root Cause:** NODE_ENV manually set to 'development' in shell environment
  - **Impact:** Causes Next.js 15 to attempt Pages Router error handling during App Router builds
  - **Solution:** Unset NODE_ENV before building: `unset NODE_ENV && npm run build`
  - **Prevention:** Never manually set NODE_ENV - let Next.js manage it automatically

  ### 🔧 Package Configuration
  - Updated package name from "portfolio" to "zachliibbe.com" for consistency with domain

  ## Technical Details

  **Why This Error Occurs:**
  1. Next.js automatically manages NODE_ENV (production during build, development during dev)
  2. Manually setting NODE_ENV overrides this and confuses the build process
  3. When NODE_ENV='development' during a production build, Next.js tries to use Pages Router error handling
  4. This causes it to look for `<Html>` component from 'next/document', which doesn't exist in App Router

  **Existing Fix:**
  - `src/app/error.tsx` already provides proper App Router error handling (created in commit 0a166b1)
  - No code changes needed, only documentation of the recurring issue

  ## Related

  - Closes Phase 9 from PRD.md
  - Previous fix: PR #95, commit 0a166b1
  - This is a **recurring issue** when NODE_ENV gets set accidentally in terminal sessions