### PR TITLE
fix(phase-22): resolve all 17 Biome warnings to 0

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -992,7 +992,7 @@ Several site behaviors are currently hard-coded or require code changes to adjus
 
 ### Phase 22: Investigate and Resolve Biome Warnings
 
-**Status:** Pending
+**Status:** Complete ✅ (2026-02-19)
 **Priority:** LOW — 17 pre-existing `warn`-severity Biome lint warnings; assess each before deciding to fix or suppress
 
 **Motivation:**
@@ -1004,10 +1004,10 @@ Several site behaviors are currently hard-coded or require code changes to adjus
 - ~15 additional warnings TBD (run `bun run check 2>&1 | grep "warn"` to enumerate)
 
 **Scope:**
-- [ ] Run `bun run check` and capture the full list of warnings
-- [ ] For each warning: decide fix / suppress / downgrade
-- [ ] Apply changes; `bun run check` should report 0 remaining warnings
-- [ ] Consider whether any rules should be elevated from `"warn"` to `"error"` in `biome.json`
+- [x] Run `bun run check` and capture the full list of warnings
+- [x] For each warning: decide fix / suppress / downgrade
+- [x] Apply changes; `bun run check` reports 0 remaining warnings
+- [x] Consider whether any rules should be elevated from `"warn"` to `"error"` in `biome.json`
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zachliibbe.com",
-  "version": "2.14.0",
+  "version": "2.14.1",
   "private": true,
   "packageManager": "bun@1.3.8",
   "scripts": {

--- a/src/app/admin/blog/components/MarkdownEditor.tsx
+++ b/src/app/admin/blog/components/MarkdownEditor.tsx
@@ -433,9 +433,12 @@ export default function MarkdownEditor({
                 placeholder="Add tag..."
                 value={newTag}
                 onChange={e => setNewTag(e.target.value)}
-                onKeyDown={e =>
-                  e.key === 'Enter' && (e.preventDefault(), handleAddTag())
-                }
+                onKeyDown={e => {
+                  if (e.key === 'Enter') {
+                    e.preventDefault();
+                    handleAddTag();
+                  }
+                }}
                 className={styles.input}
               />
               <button
@@ -520,6 +523,7 @@ export default function MarkdownEditor({
             <div className={styles.preview}>
               <div
                 className={styles.previewContent}
+                // biome-ignore lint/security/noDangerouslySetInnerHtml: admin-only markdown preview; content is trusted author input
                 dangerouslySetInnerHTML={{
                   __html: markdownToHtml(post.content),
                 }}

--- a/src/app/admin/knowledge/components/KnowledgeFileEditor.tsx
+++ b/src/app/admin/knowledge/components/KnowledgeFileEditor.tsx
@@ -121,6 +121,7 @@ export default function KnowledgeFileEditor({
           <div className={styles.preview}>
             <div
               className={styles.previewContent}
+              // biome-ignore lint/security/noDangerouslySetInnerHtml: admin-only knowledge file preview; content is trusted markdown from the knowledge base
               dangerouslySetInnerHTML={{ __html: previewContent }}
             />
           </div>

--- a/src/app/admin/knowledge/components/TestQueryInterface.tsx
+++ b/src/app/admin/knowledge/components/TestQueryInterface.tsx
@@ -161,6 +161,7 @@ export default function TestQueryInterface() {
             {exampleQueries.map((example, index) => (
               <button
                 type="button"
+                // biome-ignore lint/suspicious/noArrayIndexKey: static list of example queries; order never changes
                 key={index}
                 onClick={() => handleExampleQuery(example)}
                 className={styles.exampleButton}
@@ -186,6 +187,7 @@ export default function TestQueryInterface() {
             {testResults.map((result, index) => {
               const isExpanded = expandedResults.has(index);
               return (
+                // biome-ignore lint/suspicious/noArrayIndexKey: test results are append-only; index is a stable identity here
                 <div key={index} className={styles.resultCard}>
                   <div className={styles.resultHeader}>
                     <div className={styles.resultQuery}>
@@ -224,6 +226,7 @@ export default function TestQueryInterface() {
                       </div>
                       <div className={styles.contextChunks}>
                         {result.contextChunks.map((chunk, chunkIndex) => (
+                          // biome-ignore lint/suspicious/noArrayIndexKey: context chunks have no stable ID; index is only identifier available
                           <div key={chunkIndex} className={styles.contextChunk}>
                             <div className={styles.chunkHeader}>
                               <div className={styles.chunkSource}>

--- a/src/app/admin/unsplash/page.tsx
+++ b/src/app/admin/unsplash/page.tsx
@@ -141,6 +141,7 @@ export default function UnsplashAdminPage() {
               <ul className={styles.checklist}>
                 {status.productionRequirements.criteria.map(
                   (criterion, index) => (
+                    // biome-ignore lint/suspicious/noArrayIndexKey: static checklist with no stable IDs; order is fixed
                     <li key={index} className={styles.checklistItem}>
                       <span className={styles.checkbox}>☐</span>
                       {criterion}

--- a/src/app/blog/[slug]/page.module.css
+++ b/src/app/blog/[slug]/page.module.css
@@ -398,7 +398,6 @@ html[data-theme="light"] .postContent pre {
 .footer {
   border-top: 1px solid var(--border-color);
   padding: 2rem;
-  margin-top: 3rem;
   text-align: center;
   background: var(--background-primary);
   border-radius: 0.5rem;

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -132,6 +132,7 @@ export default async function BlogPostPage({ params }: BlogPostPageProps) {
 
                   <div
                     className={styles.postContent}
+                    // biome-ignore lint/security/noDangerouslySetInnerHtml: blog post HTML generated server-side from author-controlled markdown
                     dangerouslySetInnerHTML={{ __html: post.content }}
                   />
 

--- a/src/app/components/CurrentlyReading.tsx
+++ b/src/app/components/CurrentlyReading.tsx
@@ -52,6 +52,7 @@ export default function CurrentlyReading() {
         }
 
         // Parse the response text
+        // biome-ignore lint/suspicious/noImplicitAnyLet: assigned from JSON.parse inside try/catch; shape narrowed with Array.isArray below
         let data;
         try {
           data = JSON.parse(responseText);

--- a/src/app/components/Job.tsx
+++ b/src/app/components/Job.tsx
@@ -124,17 +124,26 @@ const Job: React.FC<JobProps> = ({
           <div className={styles.jobDetails}>
             <p>{description}</p>
             <ul>
-              {taskList.map(task =>
+              {taskList.map((task, taskIndex) =>
                 typeof task === 'string' ? (
-                  <li key={task} className={styles.jobListItem}>
+                  <li
+                    key={`${taskIndex}-${task}`}
+                    className={styles.jobListItem}
+                  >
                     {task}
                   </li>
                 ) : (
-                  <li key={task.title} className={styles.jobListItem}>
+                  <li
+                    key={`${taskIndex}-${task.title}`}
+                    className={styles.jobListItem}
+                  >
                     <div className={styles.taskTitle}>{task.title}</div>
                     <ul className={styles.subTaskList}>
-                      {task.subtasks.map(subtask => (
-                        <li key={subtask} className={styles.subTaskItem}>
+                      {task.subtasks.map((subtask, subIndex) => (
+                        <li
+                          key={`${taskIndex}-${subIndex}-${subtask}`}
+                          className={styles.subTaskItem}
+                        >
                           {subtask}
                         </li>
                       ))}

--- a/src/app/components/Job.tsx
+++ b/src/app/components/Job.tsx
@@ -124,20 +124,17 @@ const Job: React.FC<JobProps> = ({
           <div className={styles.jobDetails}>
             <p>{description}</p>
             <ul>
-              {taskList.map((task, taskIndex) =>
+              {taskList.map(task =>
                 typeof task === 'string' ? (
-                  <li key={taskIndex} className={styles.jobListItem}>
+                  <li key={task} className={styles.jobListItem}>
                     {task}
                   </li>
                 ) : (
-                  <li key={taskIndex} className={styles.jobListItem}>
+                  <li key={task.title} className={styles.jobListItem}>
                     <div className={styles.taskTitle}>{task.title}</div>
                     <ul className={styles.subTaskList}>
-                      {task.subtasks.map((subtask, subIndex) => (
-                        <li
-                          key={`${taskIndex}-${subIndex}`}
-                          className={styles.subTaskItem}
-                        >
+                      {task.subtasks.map(subtask => (
+                        <li key={subtask} className={styles.subTaskItem}>
                           {subtask}
                         </li>
                       ))}

--- a/src/app/components/Preferences/Preferences.module.css
+++ b/src/app/components/Preferences/Preferences.module.css
@@ -144,7 +144,6 @@
 }
 
 .themeName {
-  margin-left: 0.5rem;
   color: var(--text-secondary);
   justify-self: center;
   margin: 0 0 1rem 0.5rem;

--- a/src/app/contact/EmailCopy.tsx
+++ b/src/app/contact/EmailCopy.tsx
@@ -28,10 +28,15 @@ export default function EmailCopy() {
 
   return (
     <>
-      <p className={styles.emailText} onClick={handleClick}>
+      <button
+        type="button"
+        className={styles.emailText}
+        onClick={handleClick}
+        aria-label="Copy email address zliibbe@gmail.com to clipboard"
+      >
         zliibbe@gmail.com
-      </p>
-      <p className={styles.text}>Click my email to copy. ☺️ </p>
+      </button>
+      <p className={styles.text}>Click or press Enter to copy. ☺️ </p>
       <p
         className={`${styles.notification} ${
           showNotification ? styles.visible : ''

--- a/src/app/contact/page.module.css
+++ b/src/app/contact/page.module.css
@@ -90,6 +90,8 @@
   align-items: center;
   padding: 1rem 2rem;
   font-size: 1.25rem;
+  font-family: inherit;
+  border: none;
   cursor: pointer;
   color: white;
   border-radius: var(--border-radius);

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import { useEffect } from 'react';
 import styles from './page.module.css';
 
+// biome-ignore lint/suspicious/noShadowRestrictedNames: Next.js requires the error boundary export to be named exactly "Error"
 export default function Error({
   error,
   reset,

--- a/src/app/utils/index.ts
+++ b/src/app/utils/index.ts
@@ -160,7 +160,7 @@ export function getTimeAgo(timestamp: number | string): string {
 
   try {
     const now = moment();
-    let activityTime;
+    let activityTime: moment.Moment;
 
     // Handle different timestamp formats
     if (typeof timestamp === 'number') {


### PR DESCRIPTION
## Summary

Triages and resolves all 17 pre-existing Biome `warn`-severity violations. `bun run check` now reports **0 warnings and 0 errors**.

| # | Rule | File | Resolution |
|---|------|------|------------|
| 1 | `noCommaOperator` | MarkdownEditor.tsx | **Fixed** — rewritten as explicit `if` block |
| 2–4 | `noDangerouslySetInnerHtml` | MarkdownEditor, KnowledgeFileEditor, blog/[slug] | **Suppressed** — trusted author-controlled markdown |
| 5–8 | `noArrayIndexKey` | TestQueryInterface (3×), unsplash | **Suppressed** — static/append-only lists with no stable IDs |
| 9–11 | `noArrayIndexKey` | Job.tsx | **Fixed** — use task/subtask content strings as keys |
| 12–13 | `noShorthandPropertyOverrides` | blog page.module.css, Preferences.module.css | **Fixed** — removed redundant `margin-top`/`margin-left` |
| 14 | `noImplicitAnyLet` | CurrentlyReading.tsx | **Suppressed** — `JSON.parse` result; shape narrowed below |
| 15 | `noImplicitAnyLet` | utils/index.ts | **Fixed** — `let activityTime: moment.Moment` |
| 16 | `useKeyWithClickEvents` | EmailCopy.tsx | **Fixed** — `<p>` → `<button type="button">` with `aria-label`; helper text updated to "Click or press Enter to copy" |
| 17 | `noShadowRestrictedNames` | error.tsx | **Suppressed** — Next.js requires the error boundary export to be named exactly `Error` |

## Test plan

- [ ] `bun run check` reports 0 warnings and 0 errors
- [ ] Contact page: email copy button renders identically (gradient pill, same size/font)
- [ ] Contact page: Tab to email button → press Enter → email copies to clipboard
- [ ] `/work` page: job task lists render correctly
- [ ] Blog post page: content renders as before