### PR TITLE
feat: /me/health dashboard shell (auth-gated, sleep category)

### DIFF
--- a/src/app/api/me/health/[category]/route.ts
+++ b/src/app/api/me/health/[category]/route.ts
@@ -1,0 +1,48 @@
+import { type NextRequest, NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '@/lib/auth';
+import { getLatestSnapshot, getSeries } from '@/lib/garmin-health/kv';
+import type { GarminCategory, SleepSnapshot } from '@/lib/garmin-health/types';
+
+export const dynamic = 'force-dynamic';
+
+// Categories are wired up one phase at a time on the sync side; only
+// 'sleep' has real data today. Extend as 'activity' | 'activities' |
+// 'training' land.
+const SUPPORTED_CATEGORIES: readonly GarminCategory[] = ['sleep'];
+
+type RouteContext = {
+  params: Promise<{ category: string }>;
+};
+
+export async function GET(request: NextRequest, context: RouteContext) {
+  const session = await getServerSession(authOptions);
+  if (!session || session.user?.email !== 'zliibbe@gmail.com') {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const { category } = await context.params;
+  if (!SUPPORTED_CATEGORIES.includes(category as GarminCategory)) {
+    return NextResponse.json(
+      { error: `Unknown or not-yet-available category: ${category}` },
+      { status: 404 }
+    );
+  }
+
+  const { searchParams } = new URL(request.url);
+  const days = Number(searchParams.get('range') ?? '30');
+
+  try {
+    const [latest, series] = await Promise.all([
+      getLatestSnapshot<SleepSnapshot>('sleep'),
+      getSeries<SleepSnapshot>('sleep', days),
+    ]);
+    return NextResponse.json({ latest, series });
+  } catch (error) {
+    console.error(`[me/health/${category}] KV read error:`, error);
+    return NextResponse.json(
+      { error: 'Failed to load health data' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/me/health/HealthDashboard.module.css
+++ b/src/app/me/health/HealthDashboard.module.css
@@ -1,0 +1,150 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  background: var(--background-primary);
+  color: var(--text-primary);
+  min-height: 100vh;
+  margin: 0 8rem;
+  border-radius: 0.5rem;
+  padding: 2rem;
+  margin-bottom: 2rem;
+}
+
+.contentWrapper {
+  display: flex;
+  gap: 2rem;
+  padding: 0 2rem;
+  flex-grow: 1;
+}
+
+.content {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  flex-grow: 1;
+}
+
+.title {
+  font-size: 2.5rem;
+  margin-bottom: 0.5rem;
+  color: var(--text-primary);
+  display: flex;
+  justify-content: center;
+}
+
+.subtitle {
+  display: flex;
+  justify-content: center;
+  color: var(--text-secondary);
+  margin-bottom: 2rem;
+}
+
+.section {
+  margin-bottom: 3rem;
+}
+
+.sectionHeader {
+  margin-bottom: 1.5rem;
+}
+
+.sectionHeader h2 {
+  font-size: 1.5rem;
+  margin-bottom: 0.5rem;
+  color: var(--text-primary);
+}
+
+.sectionHeader p {
+  color: var(--text-secondary);
+}
+
+.error {
+  color: #f32128;
+}
+
+.loadingText {
+  color: var(--clr-neutral-200);
+  font-style: italic;
+  opacity: 0.7;
+  animation: pulse 1.5s infinite;
+}
+
+.emptyText {
+  color: var(--clr-neutral-200);
+  font-style: italic;
+  opacity: 0.7;
+}
+
+@keyframes pulse {
+  0% {
+    opacity: 0.4;
+  }
+  50% {
+    opacity: 0.7;
+  }
+  100% {
+    opacity: 0.4;
+  }
+}
+
+.statRow {
+  display: flex;
+  justify-content: space-between;
+  padding: 0.75rem 0;
+  border-bottom: 1px solid var(--clr-neutral-200);
+}
+
+.statLabel {
+  color: var(--text-secondary);
+}
+
+.statValue {
+  color: var(--text-primary);
+  font-weight: var(--fw-semi-bold);
+}
+
+.jsonDump {
+  margin-top: 1rem;
+  padding: 1rem;
+  border-radius: var(--border-radius);
+  background-color: var(--background-secondary);
+  color: var(--text-secondary);
+  font-size: var(--fs-300);
+  overflow-x: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.dayList {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 1rem;
+  list-style: none;
+  padding: 0;
+}
+
+.dayListItem {
+  padding: 0.35rem 0.75rem;
+  border-radius: var(--border-radius);
+  background-color: var(--background-secondary);
+  color: var(--text-secondary);
+  font-size: var(--fs-300);
+}
+
+@media (max-width: 768px) {
+  .container {
+    margin: 1rem 0;
+    font-size: var(--fs-300);
+  }
+
+  .contentWrapper {
+    flex-direction: column;
+    padding: 1rem;
+  }
+}
+
+@media (min-width: 769px) {
+  .container {
+    margin: 0 4rem;
+  }
+}

--- a/src/app/me/health/HealthDashboard.tsx
+++ b/src/app/me/health/HealthDashboard.tsx
@@ -1,0 +1,133 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import type { SleepSnapshot } from '@/lib/garmin-health/types';
+import styles from './HealthDashboard.module.css';
+
+interface SleepResponse {
+  latest: SleepSnapshot | null;
+  series: SleepSnapshot[];
+}
+
+export default function HealthDashboard() {
+  const [sleep, setSleep] = useState<SleepResponse | null>(null);
+  const [sleepLoading, setSleepLoading] = useState(true);
+  const [sleepError, setSleepError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchSleep = async () => {
+      try {
+        const response = await fetch('/api/me/health/sleep?range=30', {
+          cache: 'no-store',
+        });
+        if (!response.ok) {
+          throw new Error(`Failed to fetch sleep data: ${response.status}`);
+        }
+        const data = await response.json();
+        setSleep(data);
+      } catch (err: unknown) {
+        setSleepError(
+          err instanceof Error ? err.message : 'An unknown error occurred'
+        );
+      } finally {
+        setSleepLoading(false);
+      }
+    };
+
+    fetchSleep();
+  }, []);
+
+  return (
+    <main>
+      <div className="universal-gradient-container">
+        <div className="universal-gradient-background"></div>
+        <div className={styles.container}>
+          <div className={styles.contentWrapper}>
+            <div className={styles.content}>
+              <h1 className={styles.title}>Health</h1>
+              <p className={styles.subtitle}>
+                My personal health and training dashboard, synced from Garmin
+                Connect.
+              </p>
+
+              <section className={styles.section}>
+                <div className={styles.sectionHeader}>
+                  <h2>Sleep &amp; Recovery</h2>
+                  <p>
+                    Sleep, body battery, stress, HRV, and resting heart rate.
+                  </p>
+                </div>
+
+                {sleepLoading && (
+                  <p className={styles.loadingText}>Loading sleep data...</p>
+                )}
+                {sleepError && (
+                  <p className={styles.error}>Error: {sleepError}</p>
+                )}
+                {!sleepLoading && !sleepError && sleep && (
+                  <SleepSection data={sleep} />
+                )}
+              </section>
+
+              <section className={styles.section}>
+                <div className={styles.sectionHeader}>
+                  <h2>Daily Activity</h2>
+                  <p className={styles.emptyText}>Coming soon.</p>
+                </div>
+              </section>
+
+              <section className={styles.section}>
+                <div className={styles.sectionHeader}>
+                  <h2>Recent Activities</h2>
+                  <p className={styles.emptyText}>Coming soon.</p>
+                </div>
+              </section>
+
+              <section className={styles.section}>
+                <div className={styles.sectionHeader}>
+                  <h2>Advanced Training</h2>
+                  <p className={styles.emptyText}>Coming soon.</p>
+                </div>
+              </section>
+            </div>
+          </div>
+        </div>
+      </div>
+    </main>
+  );
+}
+
+// Renders the raw synced JSON rather than extracting specific fields — this
+// is a Phase 1 shell to prove the KV read path end-to-end; once real Garmin
+// sleep-response data has been seen, this becomes real stat tiles / a trend
+// chart (see the dataviz skill).
+function SleepSection({ data }: { data: SleepResponse }) {
+  if (!data.latest && data.series.length === 0) {
+    return <p className={styles.emptyText}>No sleep data synced yet.</p>;
+  }
+
+  return (
+    <div>
+      {data.latest && (
+        <>
+          <div className={styles.statRow}>
+            <span className={styles.statLabel}>Latest synced date</span>
+            <span className={styles.statValue}>{data.latest.date}</span>
+          </div>
+          <pre className={styles.jsonDump}>
+            {JSON.stringify(data.latest, null, 2)}
+          </pre>
+        </>
+      )}
+      {data.series.length > 0 && (
+        <ul className={styles.dayList}>
+          {data.series.map(snapshot => (
+            <li key={snapshot.date} className={styles.dayListItem}>
+              {snapshot.date}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/app/me/health/layout.tsx
+++ b/src/app/me/health/layout.tsx
@@ -1,0 +1,23 @@
+import type { Metadata } from 'next';
+import type React from 'react';
+
+export const metadata: Metadata = {
+  title: 'Health | Zach Liibbe',
+  description: 'Personal health and training dashboard.',
+  robots: {
+    index: false,
+    follow: false,
+    googleBot: {
+      index: false,
+      follow: false,
+    },
+  },
+};
+
+export default function HealthLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return children;
+}

--- a/src/app/me/health/page.tsx
+++ b/src/app/me/health/page.tsx
@@ -1,0 +1,13 @@
+import { redirect } from 'next/navigation';
+import { getAuthSession } from '@/lib/auth';
+import HealthDashboard from './HealthDashboard';
+
+export default async function HealthPage() {
+  const session = await getAuthSession();
+
+  if (!session) {
+    redirect('/auth/signin');
+  }
+
+  return <HealthDashboard />;
+}

--- a/src/lib/garmin-health/kv.ts
+++ b/src/lib/garmin-health/kv.ts
@@ -1,0 +1,56 @@
+import { kv } from '@vercel/kv';
+import type { GarminCategory } from './types';
+
+function dayKey(category: GarminCategory, date: string): string {
+  return `garmin:${category}:day:${date}`;
+}
+
+function seriesKey(category: GarminCategory): string {
+  return `garmin:${category}:series`;
+}
+
+function latestKey(category: GarminCategory): string {
+  return `garmin:${category}:latest`;
+}
+
+function scoreForDate(date: Date): number {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, '0');
+  const d = String(date.getDate()).padStart(2, '0');
+  return Number(`${y}${m}${d}`);
+}
+
+export async function getLatestSnapshot<T>(
+  category: GarminCategory
+): Promise<T | null> {
+  return kv.get<T>(latestKey(category));
+}
+
+/**
+ * Reads the last `days` days of a category's history: a ZRANGEBYSCORE over
+ * the date index followed by an MGET of the matching day blobs, matching
+ * the write side's index-then-blob key schema.
+ */
+export async function getSeries<T>(
+  category: GarminCategory,
+  days: number
+): Promise<T[]> {
+  const today = new Date();
+  const start = new Date(today);
+  start.setDate(start.getDate() - days);
+
+  const dates = await kv.zrange<string[]>(
+    seriesKey(category),
+    scoreForDate(start),
+    scoreForDate(today),
+    { byScore: true }
+  );
+
+  if (dates.length === 0) {
+    return [];
+  }
+
+  const keys = dates.map(date => dayKey(category, date));
+  const blobs = await kv.mget<(T | null)[]>(...keys);
+  return blobs.filter((blob): blob is T => blob !== null);
+}

--- a/src/lib/garmin-health/types.ts
+++ b/src/lib/garmin-health/types.ts
@@ -1,0 +1,18 @@
+// Mirrors the JSON shapes written by python-garminconnect's
+// scripts/sync_to_kv.py. Field names are Garmin's native response keys,
+// passed through as-is on the Python side (no remapping), so there's no
+// shared schema between the two repos to keep in sync beyond this file.
+
+export interface SleepSnapshot {
+  date: string;
+  sleep?: Record<string, unknown>;
+  body_battery?: unknown;
+  stress?: Record<string, unknown>;
+  hrv?: Record<string, unknown> | null;
+  resting_hr?: Record<string, unknown>;
+}
+
+// Categories are added one phase at a time on the Python side; only
+// 'sleep' has data today. Extend this union as 'activity' | 'activities' |
+// 'training' land.
+export type GarminCategory = 'sleep';


### PR DESCRIPTION
## Summary
- Phase 0 (shared plumbing) of the Garmin Connect health dashboard. Reads from Vercel KV only -- never talks to Garmin directly; data is written by `python-garminconnect`'s scheduled sync job (see zliibbe/python-garminconnect#1).
- `src/lib/garmin-health/kv.ts`: `getLatestSnapshot`/`getSeries` helpers, mirroring the `garmin:{category}:day/:series/:latest` key schema written by the Python side.
- `src/app/api/me/health/[category]/route.ts`: consolidated dynamic route, auth-gated exactly like `/api/admin/blog/stats` (NextAuth session + email check). Only `sleep` is wired up; other categories return 404 until their sync phases land.
- `src/app/me/health/{page,layout,HealthDashboard}`: auth-gated page mirroring `/admin`'s `getAuthSession()` + redirect pattern, styled with the same `universal-gradient` background as the rest of the site. Sleep section renders raw synced JSON for now (no UI has been designed against real field shapes yet) -- becomes real stat tiles / a trend chart once more data has flowed and the `dataviz` skill is invoked.

## Test plan
- [x] `biome check` and `tsc --noEmit` clean on the new files
- [x] Full existing test suite (42 tests) passes with no regressions
- [x] Verified locally with `bun dev`: unauthenticated requests to `/me/health` 307-redirect to `/auth/signin`; `/api/me/health/sleep` and `/api/me/health/training` both return 401 unauthenticated
- [x] Confirmed real sleep data landed in the shared KV instance after the Python sync ran (Upstash console: nonzero commands/storage)
- [ ] Sign in as zliibbe@gmail.com and confirm `/me/health` renders the synced sleep data

🤖 Generated with [Claude Code](https://claude.com/claude-code)