### PR TITLE
feat: wire up Daily Activity section (Phase 2)

### DIFF
--- a/src/app/api/me/health/[category]/route.ts
+++ b/src/app/api/me/health/[category]/route.ts
@@ -2,18 +2,36 @@ import { type NextRequest, NextResponse } from 'next/server';
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from '@/lib/auth';
 import { getLatestSnapshot, getSeries } from '@/lib/garmin-health/kv';
-import type { GarminCategory, SleepSnapshot } from '@/lib/garmin-health/types';
+import type {
+  ActivitySnapshot,
+  GarminCategory,
+  SleepSnapshot,
+} from '@/lib/garmin-health/types';
 
 export const dynamic = 'force-dynamic';
 
-// Categories are wired up one phase at a time on the sync side; only
-// 'sleep' has real data today. Extend as 'activity' | 'activities' |
-// 'training' land.
-const SUPPORTED_CATEGORIES: readonly GarminCategory[] = ['sleep'];
+// Categories are wired up one phase at a time on the sync side. Extend as
+// 'activities' | 'training' land.
+const SUPPORTED_CATEGORIES: readonly GarminCategory[] = ['sleep', 'activity'];
 
 type RouteContext = {
   params: Promise<{ category: string }>;
 };
+
+async function fetchCategoryData(category: GarminCategory, days: number) {
+  switch (category) {
+    case 'sleep':
+      return {
+        latest: await getLatestSnapshot<SleepSnapshot>('sleep'),
+        series: await getSeries<SleepSnapshot>('sleep', days),
+      };
+    case 'activity':
+      return {
+        latest: await getLatestSnapshot<ActivitySnapshot>('activity'),
+        series: await getSeries<ActivitySnapshot>('activity', days),
+      };
+  }
+}
 
 export async function GET(request: NextRequest, context: RouteContext) {
   const session = await getServerSession(authOptions);
@@ -33,11 +51,8 @@ export async function GET(request: NextRequest, context: RouteContext) {
   const days = Number(searchParams.get('range') ?? '30');
 
   try {
-    const [latest, series] = await Promise.all([
-      getLatestSnapshot<SleepSnapshot>('sleep'),
-      getSeries<SleepSnapshot>('sleep', days),
-    ]);
-    return NextResponse.json({ latest, series });
+    const data = await fetchCategoryData(category as GarminCategory, days);
+    return NextResponse.json(data);
   } catch (error) {
     console.error(`[me/health/${category}] KV read error:`, error);
     return NextResponse.json(

--- a/src/app/me/health/HealthDashboard.tsx
+++ b/src/app/me/health/HealthDashboard.tsx
@@ -1,42 +1,124 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import type { SleepSnapshot } from '@/lib/garmin-health/types';
+import type {
+  ActivitySnapshot,
+  SleepSnapshot,
+} from '@/lib/garmin-health/types';
 import styles from './HealthDashboard.module.css';
 
-interface SleepResponse {
-  latest: SleepSnapshot | null;
-  series: SleepSnapshot[];
+interface Snapshot {
+  date: string;
 }
 
-export default function HealthDashboard() {
-  const [sleep, setSleep] = useState<SleepResponse | null>(null);
-  const [sleepLoading, setSleepLoading] = useState(true);
-  const [sleepError, setSleepError] = useState<string | null>(null);
+interface CategoryResponse<T> {
+  latest: T | null;
+  series: T[];
+}
+
+function useCategoryData<T extends Snapshot>(category: string, range = 30) {
+  const [data, setData] = useState<CategoryResponse<T> | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    const fetchSleep = async () => {
+    let cancelled = false;
+
+    const fetchData = async () => {
       try {
-        const response = await fetch('/api/me/health/sleep?range=30', {
-          cache: 'no-store',
-        });
-        if (!response.ok) {
-          throw new Error(`Failed to fetch sleep data: ${response.status}`);
-        }
-        const data = await response.json();
-        setSleep(data);
-      } catch (err: unknown) {
-        setSleepError(
-          err instanceof Error ? err.message : 'An unknown error occurred'
+        const response = await fetch(
+          `/api/me/health/${category}?range=${range}`,
+          { cache: 'no-store' }
         );
+        if (!response.ok) {
+          throw new Error(
+            `Failed to fetch ${category} data: ${response.status}`
+          );
+        }
+        const json = await response.json();
+        if (!cancelled) {
+          setData(json);
+        }
+      } catch (err: unknown) {
+        if (!cancelled) {
+          setError(
+            err instanceof Error ? err.message : 'An unknown error occurred'
+          );
+        }
       } finally {
-        setSleepLoading(false);
+        if (!cancelled) {
+          setLoading(false);
+        }
       }
     };
 
-    fetchSleep();
-  }, []);
+    fetchData();
+    return () => {
+      cancelled = true;
+    };
+  }, [category, range]);
 
+  return { data, loading, error };
+}
+
+// Renders the raw synced JSON rather than extracting specific fields -- this
+// is a Phase 1-3 shell to prove the KV read path end-to-end for each
+// category; becomes real stat tiles / trend charts once the dashboard
+// redesign (dataviz skill) lands.
+function CategorySection<T extends Snapshot>({
+  category,
+  title,
+  description,
+}: {
+  category: string;
+  title: string;
+  description: string;
+}) {
+  const { data, loading, error } = useCategoryData<T>(category);
+
+  return (
+    <section className={styles.section}>
+      <div className={styles.sectionHeader}>
+        <h2>{title}</h2>
+        <p>{description}</p>
+      </div>
+
+      {loading && (
+        <p className={styles.loadingText}>Loading {title.toLowerCase()}...</p>
+      )}
+      {error && <p className={styles.error}>Error: {error}</p>}
+      {!loading && !error && data && (
+        <>
+          {!data.latest && data.series.length === 0 && (
+            <p className={styles.emptyText}>No data synced yet.</p>
+          )}
+          {data.latest && (
+            <>
+              <div className={styles.statRow}>
+                <span className={styles.statLabel}>Latest synced date</span>
+                <span className={styles.statValue}>{data.latest.date}</span>
+              </div>
+              <pre className={styles.jsonDump}>
+                {JSON.stringify(data.latest, null, 2)}
+              </pre>
+            </>
+          )}
+          {data.series.length > 0 && (
+            <ul className={styles.dayList}>
+              {data.series.map(snapshot => (
+                <li key={snapshot.date} className={styles.dayListItem}>
+                  {snapshot.date}
+                </li>
+              ))}
+            </ul>
+          )}
+        </>
+      )}
+    </section>
+  );
+}
+
+export default function HealthDashboard() {
   return (
     <main>
       <div className="universal-gradient-container">
@@ -50,31 +132,17 @@ export default function HealthDashboard() {
                 Connect.
               </p>
 
-              <section className={styles.section}>
-                <div className={styles.sectionHeader}>
-                  <h2>Sleep &amp; Recovery</h2>
-                  <p>
-                    Sleep, body battery, stress, HRV, and resting heart rate.
-                  </p>
-                </div>
+              <CategorySection<SleepSnapshot>
+                category="sleep"
+                title="Sleep & Recovery"
+                description="Sleep, body battery, stress, HRV, and resting heart rate."
+              />
 
-                {sleepLoading && (
-                  <p className={styles.loadingText}>Loading sleep data...</p>
-                )}
-                {sleepError && (
-                  <p className={styles.error}>Error: {sleepError}</p>
-                )}
-                {!sleepLoading && !sleepError && sleep && (
-                  <SleepSection data={sleep} />
-                )}
-              </section>
-
-              <section className={styles.section}>
-                <div className={styles.sectionHeader}>
-                  <h2>Daily Activity</h2>
-                  <p className={styles.emptyText}>Coming soon.</p>
-                </div>
-              </section>
+              <CategorySection<ActivitySnapshot>
+                category="activity"
+                title="Daily Activity"
+                description="Steps, calories, distance, and floors."
+              />
 
               <section className={styles.section}>
                 <div className={styles.sectionHeader}>
@@ -94,40 +162,5 @@ export default function HealthDashboard() {
         </div>
       </div>
     </main>
-  );
-}
-
-// Renders the raw synced JSON rather than extracting specific fields — this
-// is a Phase 1 shell to prove the KV read path end-to-end; once real Garmin
-// sleep-response data has been seen, this becomes real stat tiles / a trend
-// chart (see the dataviz skill).
-function SleepSection({ data }: { data: SleepResponse }) {
-  if (!data.latest && data.series.length === 0) {
-    return <p className={styles.emptyText}>No sleep data synced yet.</p>;
-  }
-
-  return (
-    <div>
-      {data.latest && (
-        <>
-          <div className={styles.statRow}>
-            <span className={styles.statLabel}>Latest synced date</span>
-            <span className={styles.statValue}>{data.latest.date}</span>
-          </div>
-          <pre className={styles.jsonDump}>
-            {JSON.stringify(data.latest, null, 2)}
-          </pre>
-        </>
-      )}
-      {data.series.length > 0 && (
-        <ul className={styles.dayList}>
-          {data.series.map(snapshot => (
-            <li key={snapshot.date} className={styles.dayListItem}>
-              {snapshot.date}
-            </li>
-          ))}
-        </ul>
-      )}
-    </div>
   );
 }

--- a/src/lib/garmin-health/types.ts
+++ b/src/lib/garmin-health/types.ts
@@ -12,7 +12,13 @@ export interface SleepSnapshot {
   resting_hr?: Record<string, unknown>;
 }
 
-// Categories are added one phase at a time on the Python side; only
-// 'sleep' has data today. Extend this union as 'activity' | 'activities' |
-// 'training' land.
-export type GarminCategory = 'sleep';
+export interface ActivitySnapshot {
+  date: string;
+  summary?: Record<string, unknown>;
+  steps?: unknown;
+  floors?: Record<string, unknown>;
+}
+
+// Categories are added one phase at a time on the Python side. Extend this
+// union as 'activities' | 'training' land.
+export type GarminCategory = 'sleep' | 'activity';


### PR DESCRIPTION
## Summary
- \`types.ts\`: adds \`ActivitySnapshot\`, extends \`GarminCategory\` to \`'sleep' | 'activity'\`.
- \`route.ts\`: generalizes the \`[category]\` handler via a category-\>fetcher switch instead of the sleep-only hardcoded \`Promise.all\`.
- \`HealthDashboard.tsx\`: extracts \`CategorySection\`/\`useCategoryData\` so each new category is one more \`<CategorySection>\` call instead of copy-pasted fetch/loading/error boilerplate. Daily Activity now renders real data; Recent Activities and Advanced Training remain "Coming soon" pending Phases 3-4.

Depends on zliibbe/python-garminconnect#3 (merged) for the \`activity\` KV category to exist.

## Test plan
- [x] Biome check clean, \`tsc --noEmit\` clean
- [x] Full test suite (42 tests) passes
- [x] Verified live with \`bun dev\` + Playwright, signed in as zliibbe@gmail.com: both Sleep & Recovery and Daily Activity render real synced data, other two sections correctly show "Coming soon", 0 console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)