### PR TITLE
feat: wire up Recent Activities section (Phase 3)

### DIFF
--- a/src/app/api/me/health/[category]/route.ts
+++ b/src/app/api/me/health/[category]/route.ts
@@ -1,9 +1,14 @@
 import { type NextRequest, NextResponse } from 'next/server';
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from '@/lib/auth';
-import { getLatestSnapshot, getSeries } from '@/lib/garmin-health/kv';
+import {
+  getLatestSnapshot,
+  getRecentActivities,
+  getSeries,
+} from '@/lib/garmin-health/kv';
 import type {
   ActivitySnapshot,
+  GarminActivity,
   GarminCategory,
   SleepSnapshot,
 } from '@/lib/garmin-health/types';
@@ -11,8 +16,12 @@ import type {
 export const dynamic = 'force-dynamic';
 
 // Categories are wired up one phase at a time on the sync side. Extend as
-// 'activities' | 'training' land.
-const SUPPORTED_CATEGORIES: readonly GarminCategory[] = ['sleep', 'activity'];
+// 'training' lands.
+const SUPPORTED_CATEGORIES: readonly GarminCategory[] = [
+  'sleep',
+  'activity',
+  'activities',
+];
 
 type RouteContext = {
   params: Promise<{ category: string }>;
@@ -30,6 +39,8 @@ async function fetchCategoryData(category: GarminCategory, days: number) {
         latest: await getLatestSnapshot<ActivitySnapshot>('activity'),
         series: await getSeries<ActivitySnapshot>('activity', days),
       };
+    case 'activities':
+      return { activities: await getRecentActivities<GarminActivity>() };
   }
 }
 

--- a/src/app/me/health/HealthDashboard.tsx
+++ b/src/app/me/health/HealthDashboard.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react';
 import type {
   ActivitySnapshot,
+  GarminActivity,
   SleepSnapshot,
 } from '@/lib/garmin-health/types';
 import styles from './HealthDashboard.module.css';
@@ -118,6 +119,78 @@ function CategorySection<T extends Snapshot>({
   );
 }
 
+// 'activities' has no per-day series (see getRecentActivities), so it can't
+// reuse CategorySection's {latest, series} shape -- bespoke fetch/render.
+function RecentActivitiesSection() {
+  const [activities, setActivities] = useState<GarminActivity[] | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const fetchData = async () => {
+      try {
+        const response = await fetch('/api/me/health/activities', {
+          cache: 'no-store',
+        });
+        if (!response.ok) {
+          throw new Error(`Failed to fetch activities: ${response.status}`);
+        }
+        const json = await response.json();
+        if (!cancelled) {
+          setActivities(json.activities ?? []);
+        }
+      } catch (err: unknown) {
+        if (!cancelled) {
+          setError(
+            err instanceof Error ? err.message : 'An unknown error occurred'
+          );
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    };
+
+    fetchData();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return (
+    <section className={styles.section}>
+      <div className={styles.sectionHeader}>
+        <h2>Recent Activities</h2>
+        <p>The most recent activities logged directly in Garmin Connect.</p>
+      </div>
+
+      {loading && (
+        <p className={styles.loadingText}>Loading recent activities...</p>
+      )}
+      {error && <p className={styles.error}>Error: {error}</p>}
+      {!loading &&
+        !error &&
+        activities &&
+        (activities.length === 0 ? (
+          <p className={styles.emptyText}>No activities synced yet.</p>
+        ) : (
+          <>
+            <div className={styles.statRow}>
+              <span className={styles.statLabel}>Synced activities</span>
+              <span className={styles.statValue}>{activities.length}</span>
+            </div>
+            <pre className={styles.jsonDump}>
+              {JSON.stringify(activities, null, 2)}
+            </pre>
+          </>
+        ))}
+    </section>
+  );
+}
+
 export default function HealthDashboard() {
   return (
     <main>
@@ -144,12 +217,7 @@ export default function HealthDashboard() {
                 description="Steps, calories, distance, and floors."
               />
 
-              <section className={styles.section}>
-                <div className={styles.sectionHeader}>
-                  <h2>Recent Activities</h2>
-                  <p className={styles.emptyText}>Coming soon.</p>
-                </div>
-              </section>
+              <RecentActivitiesSection />
 
               <section className={styles.section}>
                 <div className={styles.sectionHeader}>

--- a/src/lib/garmin-health/kv.ts
+++ b/src/lib/garmin-health/kv.ts
@@ -54,3 +54,12 @@ export async function getSeries<T>(
   const blobs = await kv.mget<(T | null)[]>(...keys);
   return blobs.filter((blob): blob is T => blob !== null);
 }
+
+/**
+ * The 'activities' category has no per-day series -- it's a flat "latest
+ * N" list wholesale-replaced each sync run, matching latestKey('activities').
+ */
+export async function getRecentActivities<T>(): Promise<T[]> {
+  const result = await kv.get<T[]>(latestKey('activities'));
+  return result ?? [];
+}

--- a/src/lib/garmin-health/types.ts
+++ b/src/lib/garmin-health/types.ts
@@ -19,6 +19,11 @@ export interface ActivitySnapshot {
   floors?: Record<string, unknown>;
 }
 
+// A single Garmin-logged activity, from get_activities(). Loosely typed
+// (Garmin's native response shape, unmapped) rather than guessed at --
+// rendered as raw JSON until the dashboard redesign.
+export type GarminActivity = Record<string, unknown>;
+
 // Categories are added one phase at a time on the Python side. Extend this
-// union as 'activities' | 'training' land.
-export type GarminCategory = 'sleep' | 'activity';
+// union as 'training' lands.
+export type GarminCategory = 'sleep' | 'activity' | 'activities';


### PR DESCRIPTION
## Summary
- \`types.ts\`: \`GarminActivity\` (loosely typed, Garmin's native shape), extends \`GarminCategory\` to include \`'activities'\`.
- \`kv.ts\`: \`getRecentActivities()\` reads the flat \`garmin:activities:latest\` list (no per-day series, unlike the other categories).
- \`route.ts\`: adds the \`'activities'\` switch case returning \`{activities}\` instead of the \`{latest, series}\` shape.
- \`HealthDashboard.tsx\`: \`RecentActivitiesSection\` is a bespoke fetch/render (can't reuse \`CategorySection\` since the data shape differs) -- renders synced activity count + raw JSON dump.

Depends on zliibbe/python-garminconnect#4 (merged) for the \`activities\` KV category to exist.

## Test plan
- [x] Biome check clean, \`tsc --noEmit\` clean
- [x] Full test suite (42 tests) passes
- [x] Verified live with \`bun dev\` + Playwright: Sleep, Daily Activity, and Recent Activities all render real synced data; Advanced Training still correctly shows "Coming soon"; 0 console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)