### PR TITLE
feat: wire up Advanced Training section (Phase 4)

### DIFF
--- a/src/app/api/me/health/[category]/route.ts
+++ b/src/app/api/me/health/[category]/route.ts
@@ -11,16 +11,17 @@ import type {
   GarminActivity,
   GarminCategory,
   SleepSnapshot,
+  TrainingSnapshot,
 } from '@/lib/garmin-health/types';
 
 export const dynamic = 'force-dynamic';
 
-// Categories are wired up one phase at a time on the sync side. Extend as
-// 'training' lands.
+// All four v1 categories are now wired up on the sync side.
 const SUPPORTED_CATEGORIES: readonly GarminCategory[] = [
   'sleep',
   'activity',
   'activities',
+  'training',
 ];
 
 type RouteContext = {
@@ -41,6 +42,11 @@ async function fetchCategoryData(category: GarminCategory, days: number) {
       };
     case 'activities':
       return { activities: await getRecentActivities<GarminActivity>() };
+    case 'training':
+      return {
+        latest: await getLatestSnapshot<TrainingSnapshot>('training'),
+        series: await getSeries<TrainingSnapshot>('training', days),
+      };
   }
 }
 

--- a/src/app/me/health/HealthDashboard.tsx
+++ b/src/app/me/health/HealthDashboard.tsx
@@ -5,6 +5,7 @@ import type {
   ActivitySnapshot,
   GarminActivity,
   SleepSnapshot,
+  TrainingSnapshot,
 } from '@/lib/garmin-health/types';
 import styles from './HealthDashboard.module.css';
 
@@ -219,12 +220,11 @@ export default function HealthDashboard() {
 
               <RecentActivitiesSection />
 
-              <section className={styles.section}>
-                <div className={styles.sectionHeader}>
-                  <h2>Advanced Training</h2>
-                  <p className={styles.emptyText}>Coming soon.</p>
-                </div>
-              </section>
+              <CategorySection<TrainingSnapshot>
+                category="training"
+                title="Advanced Training"
+                description="Training readiness/status, VO2 max, race predictions, and endurance score."
+              />
             </div>
           </div>
         </div>

--- a/src/lib/garmin-health/types.ts
+++ b/src/lib/garmin-health/types.ts
@@ -24,6 +24,14 @@ export interface ActivitySnapshot {
 // rendered as raw JSON until the dashboard redesign.
 export type GarminActivity = Record<string, unknown>;
 
-// Categories are added one phase at a time on the Python side. Extend this
-// union as 'training' lands.
-export type GarminCategory = 'sleep' | 'activity' | 'activities';
+export interface TrainingSnapshot {
+  date: string;
+  training_readiness?: unknown;
+  training_status?: Record<string, unknown>;
+  max_metrics?: Record<string, unknown>;
+  race_predictions?: Record<string, unknown>;
+  endurance_score?: Record<string, unknown>;
+}
+
+// All four v1 categories are now wired up on the Python side.
+export type GarminCategory = 'sleep' | 'activity' | 'activities' | 'training';


### PR DESCRIPTION
## Summary
- \`types.ts\`: \`TrainingSnapshot\`, \`GarminCategory\` now includes all four v1 categories.
- \`route.ts\`: \`'training'\` switch case, same \`{latest, series}\` shape as sleep/activity.
- \`HealthDashboard.tsx\`: training reuses \`CategorySection\` directly (fits the per-day shape, unlike activities) -- **"Coming soon" placeholders are now gone, all four v1 sections render real data.**

Depends on zliibbe/python-garminconnect#5 (merged) for the \`training\` KV category to exist.

This completes the v1 dashboard (sleep & recovery -\> daily activity -\> recent activities -\> advanced training, per the plan's build order). Next up: replacing the raw JSON dumps with real stat tiles/trend charts.

## Test plan
- [x] Biome check clean, \`tsc --noEmit\` clean
- [x] Full test suite (42 tests) passes
- [x] Verified live with \`bun dev\` + Playwright: all four sections render real synced data, 0 console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)