### PR TITLE
fix: home page footer floats above blank space on tall viewports

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,47 +11,50 @@ export const metadata = {
 
 export default function Home() {
   return (
-    <HomeContent>
-      {/* Design for this site courtesy of Brendan Luna (brendanluna.com) and used with permission. Thanks Brendan! */}
-      <div className="universal-gradient-container">
-        <div className="universal-gradient-background" />
-        <div className={styles.main}>
-          <section className={styles.heroSection}>
-            <p className={styles.greeting}>Hey there, I&apos;m Zach!</p>
-            <h1 className={styles.title}>
-              <span>
-                <span className={styles.titleText}>
-                  Full Stack Web Developer{' '}
+    <>
+      <HomeContent>
+        {/* Design for this site courtesy of Brendan Luna (brendanluna.com) and used with permission. Thanks Brendan! */}
+        <div className="universal-gradient-container">
+          <div className="universal-gradient-background" />
+          <div className={styles.main}>
+            <section className={styles.heroSection}>
+              <p className={styles.greeting}>Hey there, I&apos;m Zach!</p>
+              <h1 className={styles.title}>
+                <span>
+                  <span className={styles.titleText}>
+                    Full Stack Web Developer{' '}
+                  </span>
+                  <br />
+                  &amp;
+                  <span className={styles.titleText}> code craftsman</span>
                 </span>
-                <br />
-                &amp;<span className={styles.titleText}> code craftsman</span>
-              </span>
-            </h1>
-            <p className={styles.subtitle}>
-              Passionate about simple design and powerful impact
-            </p>
-          </section>
+              </h1>
+              <p className={styles.subtitle}>
+                Passionate about simple design and powerful impact
+              </p>
+            </section>
 
-          <section className={styles.homeImage}>
-            <div>
-              <div className={styles.archBlur}>
-                <Image
-                  src="/just-zach.png"
-                  alt="Photo of Zach"
-                  width={423}
-                  height={590}
-                  style={{
-                    width: 'auto',
-                    height: '100%',
-                  }}
-                  priority
-                />
+            <section className={styles.homeImage}>
+              <div>
+                <div className={styles.archBlur}>
+                  <Image
+                    src="/just-zach.png"
+                    alt="Photo of Zach"
+                    width={423}
+                    height={590}
+                    style={{
+                      width: 'auto',
+                      height: '100%',
+                    }}
+                    priority
+                  />
+                </div>
               </div>
-            </div>
-          </section>
+            </section>
+          </div>
         </div>
-      </div>
+      </HomeContent>
       <Footer />
-    </HomeContent>
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- `HomeContent` renders `<main>{children}</main>`, but `page.tsx` was passing `<Footer />` as one of those children, nesting it inside `main` instead of beside it.
- The site's sticky-footer layout (`globals.css`) relies on `main` being `flex-grow: 1` *and* `Footer` being a sibling of `main` (both direct children of `.root-container`) so `main` absorbs the extra vertical space and pushes `Footer` to the bottom.
- With `Footer` nested inside `main`, the footer floated above blank space on any viewport taller than the hero content, instead of pinning to the bottom.
- Moved `<Footer />` out of `<HomeContent>` so it's a sibling of `<main>` in the DOM — the same fix already applied to the `/me/health` dashboard layout in a separate branch.

## Test plan
- [x] `tsc --noEmit` passes
- [x] `biome check` passes
- [x] Existing test suite passes (4/4 suites, 42/42 tests — no home-page-specific tests exist)
- [x] Verified live at a 1280x1400 viewport: footer's bottom edge lands exactly at the viewport/body bottom, no gap beneath it
- [x] Verified live at a normal 1280x900 viewport: no visual regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)