### PR TITLE
fix: chat widget popups were nearly transparent, hurting readability

### DIFF
--- a/src/components/chat/FloatingChatWidget.module.css
+++ b/src/components/chat/FloatingChatWidget.module.css
@@ -526,7 +526,7 @@
   position: absolute;
   bottom: 150px;
   right: 0;
-  background: rgba(var(--theme-color-rgb, 26, 107, 138), 0.15);
+  background: rgba(var(--theme-color-rgb, 26, 107, 138), 0.94);
   backdrop-filter: blur(1rem);
   -webkit-backdrop-filter: blur(1rem);
   border: 2px solid rgba(var(--clr-neutral-400-rgb, 102, 102, 102), 0.4);
@@ -612,7 +612,7 @@
     white-space: normal;
     text-align: center;
     padding: 1rem;
-    background: rgba(var(--theme-color-rgb, 26, 107, 138), 0.15);
+    background: rgba(var(--theme-color-rgb, 26, 107, 138), 0.94);
     backdrop-filter: blur(1rem);
     -webkit-backdrop-filter: blur(1rem);
     border: 2px solid rgba(var(--clr-neutral-400-rgb, 102, 102, 102), 0.4);
@@ -866,7 +866,7 @@
   position: absolute;
   top: 40vh;
   left: 2.5rem;
-  background: rgba(var(--theme-color-rgb, 26, 107, 138), 0.15);
+  background: rgba(var(--theme-color-rgb, 26, 107, 138), 0.94);
   backdrop-filter: blur(1rem);
   -webkit-backdrop-filter: blur(1rem);
   border: 2px solid rgba(var(--clr-neutral-400-rgb, 102, 102, 102), 0.4);


### PR DESCRIPTION
## Summary
- `.greetingBubble` (the "Hi friend!" bubble) and both `.chatPrompt` rules (desktop + mobile, "Ask AI about Zach") filled with `rgba(theme-color, 0.15)` — only 15% opaque.
- Page content behind the popup bled through and fought with the text for contrast, worst on saturated themes like Sunset.
- Raised the fill to `0.94` across all three so the bubble reads as a solid card. Left the `backdrop-filter: blur`, border, and glow untouched since those weren't the source of the readability problem.

## Test plan
- [x] `biome check` passes
- [x] Verified live on `/work` (Sunset theme): bubble text is now fully legible, page content no longer bleeds through
- [x] Confirmed both the greeting bubble and the "Ask AI about Zach" prompt render as solid cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)